### PR TITLE
Support pdflatex and fix lualatex write failure under paranoid openout_any (#1, #47, #50)

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -22,6 +22,53 @@ jobs:
         with:
           name: ctan
           path: plantuml.tar.gz
+  build_pdflatex:
+    # Regression guard for pdfLaTeX support (issue #1). Mirrors build_and_ghpages
+    # but compiles the examples with pdflatex instead of lualatex.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Cache PlantUML jar
+        id: cache-plantuml
+        uses: actions/cache@v5
+        with:
+          path: /tmp/plantuml
+          key: plantuml-1.2025.1.jar
+      - name: wget PlantUML jar
+        if: steps.cache-plantuml.outputs.cache-hit != 'true'
+        run: |
+          mkdir /tmp/plantuml
+          cd /tmp/plantuml
+          wget https://github.com/plantuml/plantuml/releases/download/v1.2025.1/plantuml-1.2025.1.jar
+      - name: Set PLANTUML_JAR
+        run: echo "PLANTUML_JAR=/tmp/plantuml/plantuml-1.2025.1.jar" >> "$GITHUB_ENV"
+      - uses: actions/checkout@v6
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: graphviz inkscape
+          version: 1.1
+          execute_install_scripts: true
+      - name: Install TeX Live
+        uses: zauguin/install-texlive@v4
+        with:
+           package_file: tl_packages
+      - name: example-minimal
+        run: pdflatex -shell-escape example-minimal.tex
+      - name: example-class-relations--latex
+        run: pdflatex -shell-escape example-class-relations--latex
+      - name: example-class-relations--svg
+        run: pdflatex -shell-escape example-class-relations--svg
+      - name: example-component-diagram
+        run: pdflatex -shell-escape example-component-diagram
+      - name: example-multiple-diagrams-svg
+        run: pdflatex -shell-escape example-multiple-diagrams-svg
+      - uses: actions/upload-artifact@v6
+        with:
+          name: pdflatex-pdfs
+          path: example-*.pdf
   build_and_ghpages:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set PLANTUML_JAR
         run: echo "PLANTUML_JAR=/tmp/plantuml/plantuml-1.2025.1.jar" >> "$GITHUB_ENV"
       - uses: actions/checkout@v6
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+      - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
           packages: graphviz inkscape
           version: 1.1
@@ -91,7 +91,7 @@ jobs:
       - name: Set PLANTUML_JAR
         run: echo "PLANTUML_JAR=/tmp/plantuml/plantuml-1.2025.1.jar" >> "$GITHUB_ENV"
       - uses: actions/checkout@v6
-      - uses: awalsh128/cache-apt-pkgs-action@latest
+      - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
           packages: graphviz inkscape
           version: 1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- Added support for `pdflatex`. PlantUML is now driven directly via shell escape, mirroring the LuaLaTeX path (same `plantuml.jar` invocation and MD5-based source caching). [#1](https://github.com/koppor/plantuml/issues/1)
+- Added [architecture decision record 0001](docs/decisions/0001-support-pdflatex-via-shell-escape.md) explaining why pdfLaTeX is driven via shell escape rather than via `hvextern`, `pythontex`, or `bashful`. [#1](https://github.com/koppor/plantuml/issues/1)
+
+### Removed
+
+- Removed the unused, never-wired-up `pythontex` dependency from the non-LuaTeX code path. [#1](https://github.com/koppor/plantuml/issues/1)
 
 ## [0.6.0] - 2025-05-13
 
@@ -24,7 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed overleaf compilation. [#34](https://github.com/koppor/plantuml/issues/34)
 
-## [0.4.0] – 2024-09-17
+## [0.4.0] - 2024-09-17
 
 ### Fixed
 
@@ -32,7 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Updated command-line parameters for Inkscape. [#33](https://github.com/koppor/plantuml/pull/33)
 - Works if multiple diagrams are present. [#15](https://github.com/koppor/plantuml/issues/15), [#17](https://github.com/koppor/plantuml/issues/17)
 
-## [0.3.2] – 2023-05-12
+## [0.3.2] - 2023-05-12
 
 ### Changed
 
@@ -40,21 +51,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   introduced in PlantUML v1.2023.0. This change is not backwards compatible with
   older versions of PlantUML. [#29](https://github.com/koppor/plantuml/pull/29)
 
-## [0.3.1] – 2020-05-19
+## [0.3.1] - 2020-05-19
 
 ### Fixed
 
 - Added `-Djava.awt.headless=true` parameter to the call of `plantuml.jar` so it runs silently without interference
  the current focus
 
-## [0.3.0] – 2019-09-23
+## [0.3.0] - 2019-09-23
 
 ### Added
 
 - Added support for UTF-8 filenames.
 - Added `example-component-diagram.tex`. Refs [#9](https://github.com/koppor/plantuml/issues/9).
 
-## [0.2.3] – 2018-06-04
+## [0.2.3] - 2018-06-04
 
 ### Added
 
@@ -62,22 +73,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Removed
 
-- Removed `\usepackage{aeguill}` as 1) PlantUML seems not to rely on it any more and 2) [it is obsolete and should not be used anymore](https://tex.stackexchange.com/a/5901/9075).
+- Removed `\usepackage{aeguill}` as (1) PlantUML seems not to rely on it any more and (2) [it is obsolete and should not be used anymore](https://tex.stackexchange.com/a/5901/9075).
 
-## [0.2.2] – 2018-03-22
+## [0.2.2] - 2018-03-22
 
 ### Changed
 
 - Added version number in generated `plantuml.pdf`.
 - Do not strip down `README.md` for CTAN anymore and provide "*.png" for generation of `plantuml.pdf`.
 
-## [0.2.1] – 2018-03-21
+## [0.2.1] - 2018-03-21
 
 ### Fixed
 
 - Added short version of `README.md` to CTAN distribution again, because of [CTAN rules](https://mirror.informatik.hs-fulda.de/tex-archive/help/ctan/CTAN-upload-addendum.html#readme).
 
-## [0.2.0] – 2018-03-20
+## [0.2.0] - 2018-03-20
 
 ### Changed
 
@@ -89,10 +100,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - `release.sh` for creating a release.
 
-## 0.1.0 – 2018-03-08
+## [0.1.0] - 2018-03-08
 
-Initial public release
+### Added
 
+- Initial public release
+
+[Unreleased]: https://github.com/koppor/plantuml/compare/0.6.0...HEAD
 [0.6.0]: https://github.com/koppor/plantuml/compare/0.5.1...0.6.0
 [0.5.1]: https://github.com/koppor/plantuml/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/koppor/plantuml/compare/0.4.0...0.5.0
@@ -104,5 +118,6 @@ Initial public release
 [0.2.2]: https://github.com/koppor/plantuml/compare/0.2.1...0.2.2
 [0.2.1]: https://github.com/koppor/plantuml/compare/0.2.0...0.2.1
 [0.2.0]: https://github.com/koppor/plantuml/compare/0.1.0...0.2.0
+[0.1.0]: https://github.com/koppor/plantuml/releases/tag/0.1.0
 
 <!-- markdownlint-disable-file MD024 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-- Fixed `lualatex` failing with `I can't write on file '…-plantuml.txt'` under the paranoid `openout_any=p` setting (the default of local TeX Live and MiKTeX installations). The generated source file is now written with a relative path whenever possible, falling back to the absolute working directory only when the write is redirected (e.g. by Overleaf's output directory), so the Overleaf fix keeps working. [#50](https://github.com/koppor/plantuml/issues/50), [#42](https://github.com/koppor/plantuml/pull/42)
+- Fixed `lualatex` failing with `I can't write on file '…-plantuml.txt'` under the paranoid `openout_any=p` setting (the default of local TeX Live and MiKTeX installations). The generated source file is now written with a relative path whenever possible, falling back to the absolute working directory only when the write is redirected (e.g. by Overleaf's output directory), so the Overleaf fix keeps working. [#47](https://github.com/koppor/plantuml/issues/47), [#50](https://github.com/koppor/plantuml/issues/50), [#42](https://github.com/koppor/plantuml/pull/42)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Added support for `pdflatex`. PlantUML is now driven directly via shell escape, mirroring the LuaLaTeX path (same `plantuml.jar` invocation and MD5-based source caching). [#1](https://github.com/koppor/plantuml/issues/1)
 - Added [architecture decision record 0001](docs/decisions/0001-support-pdflatex-via-shell-escape.md) explaining why pdfLaTeX is driven via shell escape rather than via `hvextern`, `pythontex`, or `bashful`. [#1](https://github.com/koppor/plantuml/issues/1)
 
+### Fixed
+
+- Fixed `lualatex` failing with `I can't write on file '…-plantuml.txt'` under the paranoid `openout_any=p` setting (the default of local TeX Live and MiKTeX installations). The generated source file is now written with a relative path whenever possible, falling back to the absolute working directory only when the write is redirected (e.g. by Overleaf's output directory), so the Overleaf fix keeps working. [#50](https://github.com/koppor/plantuml/issues/50), [#42](https://github.com/koppor/plantuml/pull/42)
+
 ### Removed
 
 - Removed the unused, never-wired-up `pythontex` dependency from the non-LuaTeX code path. [#1](https://github.com/koppor/plantuml/issues/1)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # plantuml [![CTAN](https://img.shields.io/badge/CTAN-plantuml-blue.svg?style=flat-square)](https://ctan.org/pkg/plantuml)
 
-> A LuaLaTeX package for PlantUML in LaTeX
+> A LuaLaTeX and pdfLaTeX package for PlantUML in LaTeX
 
 [PlantUML](http://plantuml.com/) is a program which transforms text into UML diagrams.
 This package allows for embedding PlantUML diagrams using the PlantUML source.
 
-Currently, this project runs with [lualatex](http://www.luatex.org/) only.
-Check [issue #1](https://github.com/koppor/plantuml/issues/1) for the current state of affairs for support pdflatex.
+It works with both [lualatex](http://www.luatex.org/) and [pdflatex](https://www.tug.org/applications/pdftex/).
+Both engines need `-shell-escape` so that the package can call PlantUML.
+See [docs/decisions/0001-support-pdflatex-via-shell-escape.md](docs/decisions/0001-support-pdflatex-via-shell-escape.md)
+for why pdfLaTeX is driven directly via shell escape ([issue #1](https://github.com/koppor/plantuml/issues/1)).
 
 ## Preconditions
 
@@ -15,7 +17,7 @@ Check [issue #1](https://github.com/koppor/plantuml/issues/1) for the current st
 2. Windows: Environment variable `GRAPHVIZ_DOT` set to the location of `dot.exe`.
    Example: `C:\Program Files (x86)\Graphviz2.38\bin\dot.exe`.
    You can install graphviz using `choco install graphviz`.
-3. lualatex available with command line parameter `-shell-escape` included.
+3. lualatex or pdflatex available, called with the command line parameter `-shell-escape`.
 4. In case you want to have the images as PDFs (and not using TikZ or PNG), ensure that `inkscape.exe` and `pdfcrop` are in your path.
    You can get inkscape using `choco install inkscape`.
    `pdfcrop` should be part of your latex distribution.
@@ -38,7 +40,7 @@ Check [issue #1](https://github.com/koppor/plantuml/issues/1) for the current st
 \end{document}
 ```
 
-**Compilation:** `lualatex -shell-escape example-minimal`
+**Compilation:** `lualatex -shell-escape example-minimal` (or `pdflatex -shell-escape example-minimal`)
 
 **Result:**
 
@@ -92,7 +94,7 @@ Car -- Person : < owns
 \end{document}
 ```
 
-**Compilation:** `lualatex -shell-escape example-class-relations`
+**Compilation:** `lualatex -shell-escape example-class-relations` (or `pdflatex -shell-escape example-class-relations`)
 
 **Result:**
 

--- a/docs/decisions/0001-support-pdflatex-via-shell-escape.md
+++ b/docs/decisions/0001-support-pdflatex-via-shell-escape.md
@@ -1,0 +1,140 @@
+---
+status: accepted
+date: 2026-06-25
+decision-makers: Oliver Kopp
+consulted:
+informed:
+---
+
+# Support pdfLaTeX by driving PlantUML directly via shell escape
+
+## Context and Problem Statement
+
+The package historically worked with LuaLaTeX only.
+There, the `plantuml` environment shells out through `plantuml.lua`
+(`io.popen` / `os.getenv` / `lfs`) to run `plantuml.jar`.
+Under pdfLaTeX the environment was a stub that printed
+*"plantuml only works with lualatex"* ([#1]).
+
+How should pdfLaTeX run PlantUML so that `pdflatex -shell-escape file.tex`
+produces the diagrams — ideally with the same single-command workflow and the
+same caching that the LuaLaTeX path already offers?
+
+## Decision Drivers
+
+* **Single-command workflow.** `pdflatex -shell-escape file.tex` should just
+  work, exactly like LuaLaTeX — no extra build step.
+* **Parity with the LuaLaTeX path.** Same `plantuml.jar` invocation, same
+  generated files, and the same *skip-if-unchanged* caching that fixed the
+  `latexmk` rebuild loop ([#49]).
+* **Cross-platform** (Linux/macOS/Windows). Windows is an explicitly supported
+  target of the package.
+* **Minimal new dependencies**, so installation from CTAN stays easy.
+* **Support the flagship `output=latex` mode**, where PlantUML's TikZ output is
+  `\input` *inline* into the document (not a separate image/PDF).
+
+## Considered Options
+
+* **Direct shell escape (`\write18`)** from the package, mirroring the LuaLaTeX path
+* **`hvextern`** ([CTAN](https://ctan.org/pkg/hvextern))
+* **`pythontex`** ([CTAN](https://ctan.org/pkg/pythontex)) — options 1 & 2 of [#1]
+* **`bashful`** ([CTAN](https://ctan.org/pkg/bashful)) — option 4 of [#1]
+* **`checklistings`** ([CTAN](https://ctan.org/pkg/checklistings)) — option 3 of [#1]
+
+The `download` package mentioned in [#1] only fetches files and does not execute
+PlantUML, so it is not a candidate. `hvextern` (option 5) is the most actively
+maintained of the third-party options and is therefore weighed explicitly below.
+
+## Decision Outcome
+
+Chosen option: **Direct shell escape (`\write18`)**, because it is the only
+option that satisfies *every* decision driver. It reuses the exact `plantuml.jar`
+command, generated-file layout, and MD5 caching of the LuaLaTeX path; keeps the
+one-command workflow; adds no heavyweight dependencies; works cross-platform; and
+natively supports the inline-TikZ `output=latex` mode. In effect, the pdfTeX path
+becomes the `\write18` / `pdftexcmds` twin of `plantuml.lua`.
+
+### Consequences
+
+* Good, because pdfLaTeX and LuaLaTeX now behave identically (same command, same
+  files, same caching) — one mental model and one set of examples for both engines.
+* Good, because no new CTAN dependencies are pulled in: only `pdftexcmds`
+  (already required) and `iftex` are used; `PLANTUML_JAR` is read cross-platform
+  via `kpsewhich --var-value=PLANTUML_JAR`.
+* Good, because the source-MD5 cache avoids re-running PlantUML on every LaTeX
+  pass, preventing the `latexmk` rebuild loop on the pdfLaTeX side as well.
+* Neutral, because the orchestration (run command + cache) now exists twice, in
+  Lua and in TeX. The duplicated surface is small, and the TeX side adds no
+  third-party package whose breakage we would have to track.
+* Neutral, because full `-shell-escape` is required — but that was already
+  mandatory for the LuaLaTeX path.
+
+### Confirmation
+
+A CI job compiles the example documents with `pdflatex -shell-escape` (in
+addition to the existing `lualatex` jobs); the build fails if a diagram does not
+render. Manual confirmation: compiling an example twice prints
+`unchanged; skipping PlantUML` on the second run (cache hit).
+
+## Pros and Cons of the Options
+
+### Direct shell escape (`\write18`)
+
+The package writes the diagram source to `…-plantuml.txt`, then runs
+`java -jar "$PLANTUML_JAR" … -pipe -t… < src > tgt` via `\immediate\write18`,
+reads `PLANTUML_JAR` via `kpsewhich --var-value`, and hashes the source with
+`\pdf@filemdfivesum` to decide whether a re-run is needed.
+
+* Good, because byte-for-byte parity with `plantuml.lua` (same command, same outputs).
+* Good, because no third-party LaTeX package dependency, and cross-platform.
+* Good, because it supports inline-TikZ `output=latex` as well as the image modes.
+* Bad, because it duplicates a little orchestration logic across Lua and TeX.
+
+### hvextern
+
+Herbert Voß, v0.42 (2025-05-14) — the most actively maintained of the listed
+third-party options. Writes external source files and compiles them, via shell
+escape, into **separate** PDF/PNG/text outputs that are then included.
+
+* Good, because actively maintained and purpose-built for "run an external tool
+  and include the result".
+* Bad, because it produces *separate* externals; it does not fit the flagship
+  `output=latex` mode, where PlantUML's TikZ is `\input` inline.
+* Bad, because it would still require shell escape and `PLANTUML_JAR` handling,
+  while adding a dependency and a model that diverges from the LuaLaTeX path.
+
+### pythontex
+
+Geoffrey M. Poore, v0.19 (2026) — very actively maintained; executes embedded
+code (Python/Bash/…) and re-runs it only when changed.
+
+* Good, because mature, maintained, and has built-in "run only when changed".
+* Bad, because it requires a **separate `pythontex` run** between LaTeX passes,
+  breaking the single-command workflow that LuaLaTeX provides.
+* Bad, because it pulls in a Python toolchain; and [#1] itself notes the
+  difficulty of passing LaTeX counters into the executed bash code.
+
+### bashful
+
+Yossi Gil, v0.93 — last updated 2012; runs bash scripts via shell escape.
+
+* Bad, because it is Unix/bash-only ("not, without modification, in a Windows
+  environment"), failing the cross-platform driver.
+* Bad, because it is effectively unmaintained (no release since 2012).
+
+### checklistings
+
+Generates a `checklistings.sh` that the **user** has to run with an external tool.
+
+* Bad, because it breaks the single-command workflow with a manual external step.
+
+## More Information
+
+* Issue [#1] — *Support pdflatex*.
+* The LuaLaTeX implementation this mirrors: `plantuml.lua` and the `\ifluatex`
+  branch of `plantuml.sty`.
+* The caching mirrors [#49], which stopped `latexmk` from looping by running
+  PlantUML only when the source changed.
+
+[#1]: https://github.com/koppor/plantuml/issues/1
+[#49]: https://github.com/koppor/plantuml/pull/49

--- a/plantuml.sty
+++ b/plantuml.sty
@@ -11,7 +11,13 @@
 
 % Enable checking for active -shell-escape
 % Source: https://tex.stackexchange.com/a/88620/9075
+% pdftexcmds also provides the engine-agnostic helpers used by the pdflatex
+% path below: \pdf@filemdfivesum, \pdf@strcmp, and \pdf@filesize.
 \RequirePackage{pdftexcmds}
+
+% Robust \ifluatex (and friends) across engines, needed to branch between the
+% LuaTeX and pdfTeX code paths.
+\RequirePackage{iftex}
 
 % Prepare writing contents of a self-defined environment to a file
 % Source: https://tex.stackexchange.com/a/130298/9075
@@ -59,8 +65,6 @@
 \let\PlantUmlMode\l_plantuml_mode
 \ExplSyntaxOff
 
-\newcounter{PlantUmlFigureNumber}
-
 \ifluatex
   \RequirePackage{luacode}
    \directlua{
@@ -69,11 +73,114 @@
       tex.sprint("\\newcommand\\CurrentDirectory{" .. currentdir .. "/}")
     }
 \else
-  \RequirePackage[usefamily=bash]{pythontex}
+  % Non-Lua engines (e.g. pdflatex) drive PlantUML directly via shell escape
+  % (see the \plantuml@... helpers below). Everything is relative to the current
+  % working directory, so no directory prefix is required.
   \newcommand{\CurrentDirectory}{}
 \fi
 
 \makeatletter
+
+% --- Non-Lua (e.g. pdflatex) PlantUML driver ----------------------------------
+% The LuaTeX path (plantuml.lua) shells out with io.popen, reads PLANTUML_JAR
+% with os.getenv and checks files with lfs. For pdfTeX we reproduce the same
+% behaviour with engine primitives: \write18 for execution, kpsewhich (run via a
+% piped \openin) to read PLANTUML_JAR cross-platform, and the MD5/file helpers
+% from pdftexcmds to skip re-running PlantUML when the source is unchanged (the
+% same caching that plantuml.lua does, which avoids latexmk rebuild loops).
+\ifluatex\else
+  \newread\plantuml@stream
+  \newwrite\plantuml@cacheout
+  \let\plantuml@jar\@empty
+
+  % \plantuml@readline{<file>}{<cs>}: define <cs> (globally) to the first line of
+  % <file>, or to empty if the file is absent. \endlinechar=-1 strips the EOL.
+  \newcommand{\plantuml@readline}[2]{%
+    \begingroup
+      \endlinechar=-1\relax
+      \openin\plantuml@stream=#1\relax
+      \ifeof\plantuml@stream
+        \global\def#2{}%
+      \else
+        \readline\plantuml@stream to \plantuml@line
+        \global\let#2\plantuml@line
+      \fi
+      \closein\plantuml@stream
+    \endgroup
+  }
+
+  % \plantuml@readjar: read the PLANTUML_JAR environment variable into
+  % \plantuml@jar, cross-platform, via kpsewhich. Needs full shell escape, so it
+  % is only called from the shell-escape-enabled branch below.
+  \newcommand*{\plantuml@readjar}{%
+    \begingroup
+      \endlinechar=-1\relax
+      \openin\plantuml@stream=|"kpsewhich --var-value=PLANTUML_JAR"\relax
+      \ifeof\plantuml@stream
+        \global\let\plantuml@jar\@empty
+      \else
+        \readline\plantuml@stream to \plantuml@line
+        \global\let\plantuml@jar\plantuml@line
+      \fi
+      \closein\plantuml@stream
+    \endgroup
+    \ifx\plantuml@jar\@empty
+      \PackageWarning{plantuml}{Environment variable PLANTUML_JAR not set}%
+    \fi
+  }
+
+  % \plantuml@convert{<jobname>}{<mode>}: run PlantUML on <jobname>-plantuml.txt,
+  % producing <jobname>-plantuml.{tex|<mode>}. The run is skipped when the source
+  % is byte-for-byte identical to the previously converted one (MD5 cache).
+  \newcommand{\plantuml@convert}[2]{%
+    \begingroup
+      \edef\plantuml@src{#1-plantuml.txt}%
+      \ifthenelse{\equal{#2}{latex}}{%
+        % PlantUML emits the file with a .tex extension since v1.2023.0.
+        \edef\plantuml@tgt{#1-plantuml.tex}%
+        \def\plantuml@topt{latex:nopreamble}%
+      }{%
+        \edef\plantuml@tgt{#1-plantuml.#2}%
+        \def\plantuml@topt{#2}%
+      }%
+      \edef\plantuml@cache{\plantuml@src.#2.cache}%
+      \IfFileExists{\plantuml@src}{%
+        \ifx\plantuml@jar\@empty
+          \PackageWarning{plantuml}{PLANTUML_JAR not set; cannot run PlantUML}%
+        \else
+          \edef\plantuml@srcsum{\pdf@filemdfivesum{\plantuml@src}}%
+          \plantuml@readline{\plantuml@cache}{\plantuml@cachedsum}%
+          \ifnum\pdf@strcmp{\plantuml@srcsum}{\plantuml@cachedsum}=0\relax
+            \typeout{[plantuml] \plantuml@src\space unchanged; skipping PlantUML.}%
+          \else
+            \edef\plantuml@cmd{%
+              java -Djava.awt.headless=true -jar "\plantuml@jar"%
+              \space -charset UTF-8 -pipe -t\plantuml@topt
+              \space < "\plantuml@src" > "\plantuml@tgt"}%
+            \typeout{[plantuml] \plantuml@cmd}%
+            \immediate\write18{\plantuml@cmd}%
+            \IfFileExists{\plantuml@tgt}{%
+              \ifnum\pdf@filesize{\plantuml@tgt}>0\relax
+                % Cache the source MD5 so the next run can skip PlantUML.
+                \immediate\openout\plantuml@cacheout=\plantuml@cache\relax
+                \immediate\write\plantuml@cacheout{\plantuml@srcsum}%
+                \immediate\closeout\plantuml@cacheout
+              \else
+                \PackageWarning{plantuml}{PlantUML produced an empty \plantuml@tgt}%
+              \fi
+            }{%
+              \PackageWarning{plantuml}{PlantUML did not generate \plantuml@tgt}%
+            }%
+          \fi
+        \fi
+      }{%
+        \PackageWarning{plantuml}{Source \plantuml@src\space does not exist}%
+      }%
+    \endgroup
+  }
+\fi
+% ------------------------------------------------------------------------------
+
 \ifcase\pdf@shellescape
   \message{No shell escape. PlantUML cannot be called. Start pdflatex/lualatex with -shell-escape.}
   \newenvironment{plantuml}{%
@@ -87,6 +194,8 @@
         texio.write_nl("Environment variable PLANTUML_JAR not set.")
       end
     }
+  \else
+    \plantuml@readjar
   \fi
   \NewDocumentEnvironment{plantuml}{}{%
     \VerbatimOut{"\CurrentDirectory\PlantUMLJobname-plantuml.txt"}}
@@ -100,9 +209,7 @@
         convertPlantUmlToTikz(jobname, plantUmlMode)
       }
     \else
-      \stepcounter{PlantUmlFigureNumber}
-      %TODO: Execute python here
-      \typeout{*** plantuml only works with lualatex ***}
+      \plantuml@convert{\PlantUMLJobname}{\PlantUmlMode}
     \fi
     \ifthenelse{\equal{\PlantUmlMode}{latex}}{
       \begin{adjustbox}{max width=\linewidth}

--- a/plantuml.sty
+++ b/plantuml.sty
@@ -67,10 +67,30 @@
 
 \ifluatex
   \RequirePackage{luacode}
-   \directlua{
+  % Decide where the generated *-plantuml.txt must be written so that the Lua
+  % script (which uses the process working directory) can read it back.
+  %
+  % A relative \openout follows -output-directory, which on Overleaf differs
+  % from the Lua working directory (#42); an absolute path fixes that but is
+  % rejected by openout_any=p, the paranoid default of local TeX installations.
+  % So probe once: write a relative file and let Lua check whether it landed in
+  % its working directory. If yes, keep paths relative (paranoid-safe); if not
+  % (the write was redirected, e.g. on Overleaf), fall back to the absolute
+  % working directory -- exactly what #42 did.
+  \newwrite\PlantUmlProbeStream
+  \immediate\openout\PlantUmlProbeStream=openout-probe-plantuml.tmp\relax
+  \immediate\write\PlantUmlProbeStream{probe}%
+  \immediate\closeout\PlantUmlProbeStream
+  \directlua{
       local lfs = require("lfs")
-      local currentdir = lfs.currentdir():gsub("\\", "/")
-      tex.sprint("\\newcommand\\CurrentDirectory{" .. currentdir .. "/}")
+      local probe = "openout-probe-plantuml.tmp"
+      if lfs.attributes(probe) then
+        os.remove(probe)
+        tex.sprint("\\newcommand\\CurrentDirectory{}")
+      else
+        local currentdir = lfs.currentdir():gsub("\\", "/")
+        tex.sprint("\\newcommand\\CurrentDirectory{" .. currentdir .. "/}")
+      end
     }
 \else
   % Non-Lua engines (e.g. pdflatex) drive PlantUML directly via shell escape


### PR DESCRIPTION
## Summary

Two changes that make the package usable beyond the LuaLaTeX-on-Overleaf case it currently targets:

1. **Support `pdflatex`** (#1) — PlantUML is now driven directly via shell escape on non-Lua engines, mirroring the LuaLaTeX path (same `plantuml.jar` invocation and MD5-based source caching). Includes [ADR 0001](docs/decisions/0001-support-pdflatex-via-shell-escape.md) explaining why shell escape was chosen over `hvextern`, `pythontex`, or `bashful`.
2. **Fix `lualatex` write failure under paranoid `openout_any=p`** (#50, #47) — the local default of TeX Live and MiKTeX.

## The `openout_any=p` fix (#47, #50)

PR #42 (for Overleaf, #34) changed the generated `…-plantuml.txt` source from a **relative** to an **absolute** path (`\CurrentDirectory` = `lfs.currentdir()`). Absolute `\openout` paths are rejected by `openout_any=p`, the **paranoid default** of local TeX installations, so a plain `lualatex -shell-escape file.tex` died with:

```
lualatex: Not writing to …-plantuml.txt (openout_any = p; no extended check).
! I can't write on file `…-plantuml.txt'.
```

A naive revert to a relative path (as suggested in #50) would re-break Overleaf, where the relative `\openout` is redirected to a separate output directory that the Lua script can't read.

**The fix probes once at load:** write a relative file via `\openout`, then let Lua check whether it landed in Lua's working directory.

- **Landed in cwd** (normal local run) → keep paths **relative** → obeys paranoid `openout_any=p`. ✅ fixes #47, #50
- **Didn't** (redirected to an output dir, e.g. Overleaf) → fall back to the **absolute** cwd → byte-identical to #42's behavior. ✅ no regression of #34/#42

No Overleaf-specific hardcoding; it auto-adapts.

## Testing

All in Docker (`registry.gitlab.com/islandoftex/images/texlive`):

- **Local paranoid `openout_any=p`**: all 5 examples (TikZ + SVG modes) compile — the entire local LuaLaTeX path was broken before. Probe temp file is cleaned up, no strays.
- **Simulated Overleaf** (`-output-directory` + `openout_any=a`): still works; source written to Lua's cwd.
- **pdflatex**: all 5 examples compile (latex + svg modes, cache hit/invalidation verified).

CI gains a `build_pdflatex` job as a regression guard.

Closes #1
Closes #47
Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)
