### PR TITLE
Support PlantUML under -output-directory (#27)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,12 +26,24 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+      # The check runs against the *latest* PlantUML so it catches breakage with
+      # new releases. The cache key is the resolved version, so it refreshes
+      # automatically whenever PlantUML publishes a new release.
+      - name: Resolve latest PlantUML version
+        id: plantuml-version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag=$(gh api repos/plantuml/plantuml/releases/latest --jq '.tag_name')
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+          echo "Latest PlantUML: ${tag#v}"
       - name: Download PlantUML jar (cached)
         id: plantuml-jar
         uses: ethanjli/cached-download-action@v0.1.4
         with:
-          url: https://github.com/plantuml/plantuml/releases/download/v1.2025.1/plantuml-1.2025.1.jar
-          destination: /tmp/plantuml/plantuml-1.2025.1.jar
+          url: https://github.com/plantuml/plantuml/releases/download/v${{ steps.plantuml-version.outputs.version }}/plantuml-${{ steps.plantuml-version.outputs.version }}.jar
+          destination: /tmp/plantuml/plantuml-${{ steps.plantuml-version.outputs.version }}.jar
+          cache-key: plantuml-${{ steps.plantuml-version.outputs.version }}.jar
       - name: Set PLANTUML_JAR
         run: echo "PLANTUML_JAR=${{ steps.plantuml-jar.outputs.destination }}" >> "$GITHUB_ENV"
       - uses: actions/checkout@v6

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,64 @@
+name: Check
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+permissions:
+  contents: read
+concurrency:
+  group: "${{ github.workflow }}-${{ github.head_ref || github.ref }}"
+  cancel-in-progress: true
+jobs:
+  output-directory:
+    # Regression test for #27: PlantUML must work when LaTeX is run with
+    # -output-directory. Compiles every example into ./out with both engines and
+    # checks that the resulting PDF lands in that directory.
+    strategy:
+      fail-fast: false
+      matrix:
+        engine: [lualatex, pdflatex]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Download PlantUML jar (cached)
+        id: plantuml-jar
+        uses: ethanjli/cached-download-action@v0.1.4
+        with:
+          url: https://github.com/plantuml/plantuml/releases/download/v1.2025.1/plantuml-1.2025.1.jar
+          destination: /tmp/plantuml/plantuml-1.2025.1.jar
+      - name: Set PLANTUML_JAR
+        run: echo "PLANTUML_JAR=${{ steps.plantuml-jar.outputs.destination }}" >> "$GITHUB_ENV"
+      - uses: actions/checkout@v6
+      - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
+        with:
+          packages: graphviz inkscape
+          version: 1.1
+          execute_install_scripts: true
+      - name: Install TeX Live
+        uses: zauguin/install-texlive@v4
+        with:
+          package_file: tl_packages
+      - name: Compile examples with -output-directory
+        run: |
+          mkdir -p out
+          for example in \
+            example-minimal \
+            example-class-relations--latex \
+            example-class-relations--svg \
+            example-component-diagram \
+            example-multiple-diagrams-svg; do
+            echo "::group::${{ matrix.engine }} -output-directory=out $example"
+            ${{ matrix.engine }} -shell-escape -interaction=nonstopmode -halt-on-error -output-directory=out "$example"
+            echo "::endgroup::"
+            test -f "out/$example.pdf" || { echo "::error::out/$example.pdf was not produced"; exit 1; }
+          done
+      - uses: actions/upload-artifact@v7
+        with:
+          name: output-directory-${{ matrix.engine }}
+          path: out/*.pdf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,12 +31,21 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+      - name: Resolve latest PlantUML version
+        id: plantuml-version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag=$(gh api repos/plantuml/plantuml/releases/latest --jq '.tag_name')
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+          echo "Latest PlantUML: ${tag#v}"
       - name: Download PlantUML jar (cached)
         id: plantuml-jar
         uses: ethanjli/cached-download-action@v0.1.4
         with:
-          url: https://github.com/plantuml/plantuml/releases/download/v1.2025.1/plantuml-1.2025.1.jar
-          destination: /tmp/plantuml/plantuml-1.2025.1.jar
+          url: https://github.com/plantuml/plantuml/releases/download/v${{ steps.plantuml-version.outputs.version }}/plantuml-${{ steps.plantuml-version.outputs.version }}.jar
+          destination: /tmp/plantuml/plantuml-${{ steps.plantuml-version.outputs.version }}.jar
+          cache-key: plantuml-${{ steps.plantuml-version.outputs.version }}.jar
       - name: Set PLANTUML_JAR
         run: echo "PLANTUML_JAR=${{ steps.plantuml-jar.outputs.destination }}" >> "$GITHUB_ENV"
       - uses: actions/checkout@v6
@@ -70,12 +79,21 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+      - name: Resolve latest PlantUML version
+        id: plantuml-version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag=$(gh api repos/plantuml/plantuml/releases/latest --jq '.tag_name')
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+          echo "Latest PlantUML: ${tag#v}"
       - name: Download PlantUML jar (cached)
         id: plantuml-jar
         uses: ethanjli/cached-download-action@v0.1.4
         with:
-          url: https://github.com/plantuml/plantuml/releases/download/v1.2025.1/plantuml-1.2025.1.jar
-          destination: /tmp/plantuml/plantuml-1.2025.1.jar
+          url: https://github.com/plantuml/plantuml/releases/download/v${{ steps.plantuml-version.outputs.version }}/plantuml-${{ steps.plantuml-version.outputs.version }}.jar
+          destination: /tmp/plantuml/plantuml-${{ steps.plantuml-version.outputs.version }}.jar
+          cache-key: plantuml-${{ steps.plantuml-version.outputs.version }}.jar
       - name: Set PLANTUML_JAR
         run: echo "PLANTUML_JAR=${{ steps.plantuml-jar.outputs.destination }}" >> "$GITHUB_ENV"
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Release
 on:
   pull_request:
   push:
@@ -31,20 +31,14 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-      - name: Cache PlantUML jar
-        id: cache-plantuml
-        uses: actions/cache@v5
+      - name: Download PlantUML jar (cached)
+        id: plantuml-jar
+        uses: ethanjli/cached-download-action@v0.1.4
         with:
-          path: /tmp/plantuml
-          key: plantuml-1.2025.1.jar
-      - name: wget PlantUML jar
-        if: steps.cache-plantuml.outputs.cache-hit != 'true'
-        run: |
-          mkdir /tmp/plantuml
-          cd /tmp/plantuml
-          wget https://github.com/plantuml/plantuml/releases/download/v1.2025.1/plantuml-1.2025.1.jar
+          url: https://github.com/plantuml/plantuml/releases/download/v1.2025.1/plantuml-1.2025.1.jar
+          destination: /tmp/plantuml/plantuml-1.2025.1.jar
       - name: Set PLANTUML_JAR
-        run: echo "PLANTUML_JAR=/tmp/plantuml/plantuml-1.2025.1.jar" >> "$GITHUB_ENV"
+        run: echo "PLANTUML_JAR=${{ steps.plantuml-jar.outputs.destination }}" >> "$GITHUB_ENV"
       - uses: actions/checkout@v6
       - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
@@ -76,20 +70,14 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-      - name: Cache PlantUML jar
-        id: cache-plantuml
-        uses: actions/cache@v5
+      - name: Download PlantUML jar (cached)
+        id: plantuml-jar
+        uses: ethanjli/cached-download-action@v0.1.4
         with:
-          path: /tmp/plantuml
-          key: plantuml-1.2025.1.jar
-      - name: wget PlantUML jar
-        if: steps.cache-plantuml.outputs.cache-hit != 'true'
-        run: |
-          mkdir /tmp/plantuml
-          cd /tmp/plantuml
-          wget https://github.com/plantuml/plantuml/releases/download/v1.2025.1/plantuml-1.2025.1.jar
+          url: https://github.com/plantuml/plantuml/releases/download/v1.2025.1/plantuml-1.2025.1.jar
+          destination: /tmp/plantuml/plantuml-1.2025.1.jar
       - name: Set PLANTUML_JAR
-        run: echo "PLANTUML_JAR=/tmp/plantuml/plantuml-1.2025.1.jar" >> "$GITHUB_ENV"
+        run: echo "PLANTUML_JAR=${{ steps.plantuml-jar.outputs.destination }}" >> "$GITHUB_ENV"
       - uses: actions/checkout@v6
       - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - Fixed `lualatex` failing with `I can't write on file '…-plantuml.txt'` under the paranoid `openout_any=p` setting (the default of local TeX Live and MiKTeX installations). The generated source file is now written with a relative path whenever possible, falling back to the absolute working directory only when the write is redirected (e.g. by Overleaf's output directory), so the Overleaf fix keeps working. [#47](https://github.com/koppor/plantuml/issues/47), [#50](https://github.com/koppor/plantuml/issues/50), [#42](https://github.com/koppor/plantuml/pull/42)
+- Fixed PlantUML diagrams not being found when LaTeX is run with `-output-directory`. The generated source is now read from, and the diagram written to, that directory (located via `TEXMF_OUTPUT_DIRECTORY`). The variable is additionally cleared for the PlantUML subprocess, which otherwise hangs when it holds a relative path. Works for both `lualatex` and `pdflatex`. [#27](https://github.com/koppor/plantuml/issues/27)
 
 ### Removed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# CLAUDE.md
+
+Guidance for working in this repository.
+
+This is the `plantuml` LaTeX package (CTAN): a LuaLaTeX/pdfLaTeX package
+(`plantuml.sty` + `plantuml.lua`) that embeds PlantUML diagrams by shelling out
+to `plantuml.jar`. It requires `-shell-escape` and the `PLANTUML_JAR`
+environment variable (see `README.md`).
+
+## Updating PlantUML
+
+CI does **not** pin a PlantUML version. Both `.github/workflows/check.yml` and
+`.github/workflows/release.yml` resolve the latest release at run time:
+
+```sh
+gh api repos/plantuml/plantuml/releases/latest --jq '.tag_name'
+```
+
+and download `plantuml-<version>.jar` via `ethanjli/cached-download-action`. The
+download cache is keyed on the resolved version, so it refreshes automatically
+whenever PlantUML publishes a new release — there is nothing to bump by hand.
+
+- **`check.yml`** compiles the examples with `-output-directory` against the
+  latest PlantUML, so we notice when a new PlantUML release breaks the package.
+- **`release.yml`** builds the CTAN package and GitHub Pages with the same
+  latest jar.
+
+To **pin** a specific version instead, replace the "Resolve latest PlantUML
+version" step with a fixed value, e.g.:
+
+```yaml
+      - name: Resolve PlantUML version
+        id: plantuml-version
+        run: echo "version=1.2025.1" >> "$GITHUB_OUTPUT"
+```
+
+Locally, point `PLANTUML_JAR` at any jar; grab the latest from
+<https://github.com/plantuml/plantuml/releases/latest/download/plantuml.jar>.
+
+## Testing changes
+
+Compile the examples with `-shell-escape` (optionally adding `-output-directory`)
+using `lualatex` or `pdflatex`. Run the LaTeX toolchain inside Docker rather than
+on the host.

--- a/plantuml.lua
+++ b/plantuml.lua
@@ -3,9 +3,15 @@
 require "lfs"
 
 -- @param mode directly passed to PlantUML. Recommended: png, svg, pdf (requires Apache Batik to convert svg to pdf)
-function convertPlantUmlToTikz(jobname, mode)
-  local plantUmlSourceFilename = jobname .. "-plantuml.txt"
-  local plantUmlTargetFilename = jobname .. "-plantuml." .. mode
+-- @param iodir directory prefix (with trailing slash) where the generated
+--   *-plantuml.* files live. Empty unless lualatex runs with -output-directory:
+--   LaTeX redirects its writes there, but this script (a shell-escape
+--   subprocess) runs in the real working directory, so it must reach in
+--   explicitly. See plantuml.sty for how the prefix is determined (#27).
+function convertPlantUmlToTikz(jobname, mode, iodir)
+  iodir = iodir or ""
+  local plantUmlSourceFilename = iodir .. jobname .. "-plantuml.txt"
+  local plantUmlTargetFilename = iodir .. jobname .. "-plantuml." .. mode
 
   if not (lfs.attributes(plantUmlSourceFilename)) then
     texio.write_nl("Source " .. plantUmlSourceFilename .. " does not exist.")
@@ -48,7 +54,7 @@ function convertPlantUmlToTikz(jobname, mode)
   if (mode == "latex") then
     cmd = cmd .. "latex:nopreamble"
     -- plantuml has changed output format in https://github.com/plantuml/plantuml/pull/1237
-    plantUmlTargetFilename = jobname .. "-plantuml.tex"
+    plantUmlTargetFilename = iodir .. jobname .. "-plantuml.tex"
   else
     cmd = cmd .. mode
   end
@@ -56,13 +62,20 @@ function convertPlantUmlToTikz(jobname, mode)
 
   cmd = cmd .. [[ < "]] .. plantUmlSourceFilename .. [[" > "]] .. plantUmlTargetFilename .. [["]]
   texio.write_nl(cmd)
+  -- PlantUML (the JVM) hangs when TEXMF_OUTPUT_DIRECTORY holds a relative path,
+  -- which is exactly what lualatex sets when run with a relative
+  -- -output-directory. Clear it for the child process only, then restore. (#27)
+  local savedOutDir = os.getenv("TEXMF_OUTPUT_DIRECTORY")
+  if savedOutDir and savedOutDir ~= "" then os.setenv("TEXMF_OUTPUT_DIRECTORY", "") end
   local handle,error = io.popen(cmd)
   if not handle then
+    if savedOutDir and savedOutDir ~= "" then os.setenv("TEXMF_OUTPUT_DIRECTORY", savedOutDir) end
     texio.write_nl("Error during execution of PlantUML.")
     texio.write_nl(error)
     return
   end
   io.close(handle)
+  if savedOutDir and savedOutDir ~= "" then os.setenv("TEXMF_OUTPUT_DIRECTORY", savedOutDir) end
 
   if not (lfs.attributes(plantUmlTargetFilename)) then
     texio.write_nl("PlantUML did not generate anything.")

--- a/plantuml.sty
+++ b/plantuml.sty
@@ -65,38 +65,76 @@
 \let\PlantUmlMode\l_plantuml_mode
 \ExplSyntaxOff
 
+% PlantUML runs as a shell-escape subprocess, which executes in the real
+% working directory. LaTeX's own writes (\openout) and reads (\input,
+% \IfFileExists, ...) are instead redirected into -output-directory when one is
+% set, so the two sides disagree about where the generated *-plantuml.* files
+% live. Two prefixes bridge that gap:
+%
+%   \CurrentDirectory  prefixes LaTeX's \openout of the source file.
+%   \PlantUmlIODir     prefixes everything the shell side touches (reading the
+%                      source, writing the diagram) so it reaches into the
+%                      output directory.
+%
+% Modern TeX Live (>=2023) exposes the output directory to subprocesses via the
+% TEXMF_OUTPUT_DIRECTORY environment variable. When present we keep the source
+% \openout relative (TeX redirects it into the output directory, which
+% openout_any=p allows) and point the shell side at that directory -- this fixes
+% -output-directory (#27), including the paranoid openout_any=p default of local
+% TeX installations (#47, #50).
+%
+% Without that variable (older engines, some Overleaf setups, #42) we probe:
+% write a relative file and let Lua check whether it landed in the working
+% directory. If yes, everything stays relative; if not (the write was
+% redirected), fall back to the absolute working directory for both sides --
+% exactly what #42 did.
 \ifluatex
   \RequirePackage{luacode}
-  % Decide where the generated *-plantuml.txt must be written so that the Lua
-  % script (which uses the process working directory) can read it back.
-  %
-  % A relative \openout follows -output-directory, which on Overleaf differs
-  % from the Lua working directory (#42); an absolute path fixes that but is
-  % rejected by openout_any=p, the paranoid default of local TeX installations.
-  % So probe once: write a relative file and let Lua check whether it landed in
-  % its working directory. If yes, keep paths relative (paranoid-safe); if not
-  % (the write was redirected, e.g. on Overleaf), fall back to the absolute
-  % working directory -- exactly what #42 did.
   \newwrite\PlantUmlProbeStream
   \immediate\openout\PlantUmlProbeStream=openout-probe-plantuml.tmp\relax
   \immediate\write\PlantUmlProbeStream{probe}%
   \immediate\closeout\PlantUmlProbeStream
   \directlua{
       local lfs = require("lfs")
-      local probe = "openout-probe-plantuml.tmp"
-      if lfs.attributes(probe) then
-        os.remove(probe)
-        tex.sprint("\\newcommand\\CurrentDirectory{}")
+      local outdir = os.getenv("TEXMF_OUTPUT_DIRECTORY")
+      if outdir and outdir:len() > 0 then
+        outdir = outdir:gsub("\\", "/") .. "/"
+        os.remove(outdir .. "openout-probe-plantuml.tmp")
+        os.remove("openout-probe-plantuml.tmp")
+        tex.sprint("\\gdef\\CurrentDirectory{}")
+        tex.sprint("\\gdef\\PlantUmlIODir{" .. outdir .. "}")
       else
-        local currentdir = lfs.currentdir():gsub("\\", "/")
-        tex.sprint("\\newcommand\\CurrentDirectory{" .. currentdir .. "/}")
+        local probe = "openout-probe-plantuml.tmp"
+        if lfs.attributes(probe) then
+          os.remove(probe)
+          tex.sprint("\\gdef\\CurrentDirectory{}")
+          tex.sprint("\\gdef\\PlantUmlIODir{}")
+        else
+          local currentdir = lfs.currentdir():gsub("\\", "/")
+          tex.sprint("\\gdef\\CurrentDirectory{" .. currentdir .. "/}")
+          tex.sprint("\\gdef\\PlantUmlIODir{" .. currentdir .. "/}")
+        end
       end
     }
 \else
   % Non-Lua engines (e.g. pdflatex) drive PlantUML directly via shell escape
-  % (see the \plantuml@... helpers below). Everything is relative to the current
-  % working directory, so no directory prefix is required.
+  % (see the \plantuml@... helpers below). \CurrentDirectory stays empty (the
+  % source \openout is relative, so TeX redirects it into any -output-directory);
+  % \PlantUmlIODir is filled in from TEXMF_OUTPUT_DIRECTORY in the shell-escape
+  % branch below so the \write18 invocation can reach the files there (#27).
   \newcommand{\CurrentDirectory}{}
+  \newcommand{\PlantUmlIODir}{}
+  % PlantUML (the JVM) hangs when TEXMF_OUTPUT_DIRECTORY holds a relative path,
+  % which is what pdflatex sets under a relative -output-directory. We clear it
+  % for the PlantUML child by prefixing the call with \PlantUmlEnvReset, which is
+  % set to \PlantUmlUnsetPrefix only while an output directory is in effect (#27).
+  % POSIX uses "env -u"; on Windows the prefix is left empty (untested combo).
+  \newcommand{\PlantUmlEnvReset}{}
+  \ExplSyntaxOn
+    \sys_if_platform_windows:TF
+      { \gdef\PlantUmlUnsetPrefix { } }
+      { \gdef\PlantUmlUnsetPrefix { env\space-u\space TEXMF_OUTPUT_DIRECTORY\space } }
+  \ExplSyntaxOff
 \fi
 
 \makeatletter
@@ -149,6 +187,27 @@
     \fi
   }
 
+  % \plantuml@readoutdir: read TEXMF_OUTPUT_DIRECTORY into \PlantUmlIODir (with a
+  % trailing slash) so the \write18 PlantUML call can reach files written into a
+  % -output-directory. Cross-platform via kpsewhich, like \plantuml@readjar. Left
+  % empty when no output directory is in effect. Needs shell escape.
+  \newcommand*{\plantuml@readoutdir}{%
+    \begingroup
+      \endlinechar=-1\relax
+      \openin\plantuml@stream=|"kpsewhich --var-value=TEXMF_OUTPUT_DIRECTORY"\relax
+      \ifeof\plantuml@stream
+      \else
+        \readline\plantuml@stream to \plantuml@line
+        \ifx\plantuml@line\@empty
+        \else
+          \xdef\PlantUmlIODir{\plantuml@line/}%
+          \global\let\PlantUmlEnvReset\PlantUmlUnsetPrefix
+        \fi
+      \fi
+      \closein\plantuml@stream
+    \endgroup
+  }
+
   % \plantuml@convert{<jobname>}{<mode>}: run PlantUML on <jobname>-plantuml.txt,
   % producing <jobname>-plantuml.{tex|<mode>}. The run is skipped when the source
   % is byte-for-byte identical to the previously converted one (MD5 cache).
@@ -174,13 +233,14 @@
             \typeout{[plantuml] \plantuml@src\space unchanged; skipping PlantUML.}%
           \else
             \edef\plantuml@cmd{%
+              \PlantUmlEnvReset
               java -Djava.awt.headless=true -jar "\plantuml@jar"%
               \space -charset UTF-8 -pipe -t\plantuml@topt
-              \space < "\plantuml@src" > "\plantuml@tgt"}%
+              \space < "\PlantUmlIODir\plantuml@src" > "\PlantUmlIODir\plantuml@tgt"}%
             \typeout{[plantuml] \plantuml@cmd}%
             \immediate\write18{\plantuml@cmd}%
-            \IfFileExists{\plantuml@tgt}{%
-              \ifnum\pdf@filesize{\plantuml@tgt}>0\relax
+            \IfFileExists{\PlantUmlIODir\plantuml@tgt}{%
+              \ifnum\pdf@filesize{\PlantUmlIODir\plantuml@tgt}>0\relax
                 % Cache the source MD5 so the next run can skip PlantUML.
                 \immediate\openout\plantuml@cacheout=\plantuml@cache\relax
                 \immediate\write\plantuml@cacheout{\plantuml@srcsum}%
@@ -216,6 +276,7 @@
     }
   \else
     \plantuml@readjar
+    \plantuml@readoutdir
   \fi
   \NewDocumentEnvironment{plantuml}{}{%
     \VerbatimOut{"\CurrentDirectory\PlantUMLJobname-plantuml.txt"}}
@@ -225,18 +286,19 @@
       \directlua{
         local jobname=\luastring{\PlantUMLJobname}
         local plantUmlMode=\luastring{\PlantUmlMode}
+        local plantUmlIODir=\luastring{\PlantUmlIODir}
         require("plantuml.lua")
-        convertPlantUmlToTikz(jobname, plantUmlMode)
+        convertPlantUmlToTikz(jobname, plantUmlMode, plantUmlIODir)
       }
     \else
       \plantuml@convert{\PlantUMLJobname}{\PlantUmlMode}
     \fi
     \ifthenelse{\equal{\PlantUmlMode}{latex}}{
       \begin{adjustbox}{max width=\linewidth}
-        \input{\PlantUMLJobname-plantuml.tex}
+        \input{\PlantUmlIODir\PlantUMLJobname-plantuml.tex}
       \end{adjustbox}
     }{
-      \includegraphics[width=\maxwidth{\textwidth}]{\PlantUMLJobname-plantuml.\PlantUmlMode}
+      \includegraphics[width=\maxwidth{\textwidth}]{\PlantUmlIODir\PlantUMLJobname-plantuml.\PlantUmlMode}
       \UMLcountUp
     }
   }


### PR DESCRIPTION
Fixes #27.

When LaTeX runs with `-output-directory`, PlantUML could not find the generated files (`lualatex -shell-escape -output-directory=out` failed with `I can't write on file '…-plantuml.txt'`). Diagnosing it in Docker surfaced **two independent root causes**, both fixed here.

## 1. Path mismatch
With `-output-directory`, LaTeX redirects its writes/reads into that directory, but the PlantUML shell-escape subprocess runs in the *real* working directory. So LaTeX wrote the source into `out/` while PlantUML looked in the CWD.

- The source `\openout` stays **relative** (TeX redirects it into the output dir, which `openout_any=p` allows — keeping the #47/#50 paranoid-write fix intact).
- The shell side now reaches into the output dir via a prefix obtained from `TEXMF_OUTPUT_DIRECTORY` (`os.getenv` for lualatex, `kpsewhich` for pdflatex).
- A probe-based fallback preserves the existing Overleaf behavior (#42) when that variable is absent.

## 2. PlantUML/JVM hang on a relative `TEXMF_OUTPUT_DIRECTORY`
Once paths were fixed, PlantUML *hung*. Bisected to: **PlantUML hangs whenever `TEXMF_OUTPUT_DIRECTORY` holds a relative path** in its environment — exactly what a relative `-output-directory` sets. Confirmed in plain bash (no LaTeX): relative `out` hangs; absolute, empty, or a different variable name all work.

The variable is now cleared **for the PlantUML child only** (`os.setenv` for lualatex; an `env -u` prefix for pdflatex on POSIX).

> Note: the hang itself is a PlantUML bug; this PR works around it. Worth reporting upstream.

## Verification (Docker, TeX Live)

| | no `-output-directory` | `-output-directory=out` (#27) |
|---|---|---|
| lualatex | ✅ | ✅ (was ❌) |
| pdflatex | ✅ | ✅ (was ❌) |

Also verified: `latex` **and** `png` modes (the `\includegraphics`/figure-counter path), multi-diagram documents, and that the MD5 cache still skips re-runs on recompile — all under `-output-directory`. The plain (no-output-directory) path is byte-identical to before.

## Caveats
- **Windows + pdflatex + relative `-output-directory`** is left as a no-op env reset (untested; `env -u` is POSIX). lualatex on Windows is covered via `os.setenv`. The common no-output-directory case is unchanged on all platforms.
- `svg` (needs Inkscape) and graphviz-based diagrams weren't run locally; their only change is the same output-dir prefix as `png`/`latex`, so CI covers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
