### PR TITLE
Export SVG text as paths in Inkscape conversion (#25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Fixed `lualatex` failing with `I can't write on file '…-plantuml.txt'` under the paranoid `openout_any=p` setting (the default of local TeX Live and MiKTeX installations). The generated source file is now written with a relative path whenever possible, falling back to the absolute working directory only when the write is redirected (e.g. by Overleaf's output directory), so the Overleaf fix keeps working. [#47](https://github.com/koppor/plantuml/issues/47), [#50](https://github.com/koppor/plantuml/issues/50), [#42](https://github.com/koppor/plantuml/pull/42)
 - Fixed PlantUML diagrams not being found when LaTeX is run with `-output-directory`. The generated source is now read from, and the diagram written to, that directory (located via `TEXMF_OUTPUT_DIRECTORY`). The variable is additionally cleared for the PlantUML subprocess, which otherwise hangs when it holds a relative path. Works for both `lualatex` and `pdflatex`. [#27](https://github.com/koppor/plantuml/issues/27)
+- Fixed garbled text in the SVG examples by exporting text as paths (`--export-text-to-path`) in the Inkscape conversion rule, making the rendering independent of the fonts available to Inkscape. [#25](https://github.com/koppor/plantuml/issues/25)
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ for why pdfLaTeX is driven directly via shell escape ([issue #1](https://github.
 \usepackage{graphics}
 \usepackage{epstopdf}
 \epstopdfDeclareGraphicsRule{.svg}{pdf}{.pdf}{
-  inkscape "#1" --export-filename="\OutputFile"
+  inkscape "#1" --export-text-to-path --export-filename="\OutputFile"
 }
 \usepackage[output=svg]{plantuml}
 \begin{document}

--- a/example-class-relations--svg.tex
+++ b/example-class-relations--svg.tex
@@ -8,7 +8,7 @@
 % We just include the SVG as is.
 \usepackage{epstopdf}
 \epstopdfDeclareGraphicsRule{.svg}{pdf}{.pdf}{%
-  inkscape "#1" --export-filename="\OutputFile"
+  inkscape "#1" --export-text-to-path --export-filename="\OutputFile"
 }
 
 \usepackage[output=svg]{plantuml}

--- a/example-component-diagram.tex
+++ b/example-component-diagram.tex
@@ -7,7 +7,7 @@
 % We just include the SVG as is.
 \usepackage{epstopdf}
 \epstopdfDeclareGraphicsRule{.svg}{pdf}{.pdf}{%
-  inkscape "#1" --export-filename="\OutputFile"
+  inkscape "#1" --export-text-to-path --export-filename="\OutputFile"
 }
 
 \usepackage[output=svg]{plantuml}

--- a/example-multiple-diagrams-svg.tex
+++ b/example-multiple-diagrams-svg.tex
@@ -4,7 +4,7 @@
 
 \usepackage{epstopdf}
 \epstopdfDeclareGraphicsRule{.svg}{pdf}{.pdf}{%
-  inkscape "#1" --export-filename="\OutputFile"
+  inkscape "#1" --export-text-to-path --export-filename="\OutputFile"
 }
 
 \usepackage[output=svg]{plantuml}


### PR DESCRIPTION
Closes #25.

The inkscape 1.x CLI change reported in #25 (`-z --file= --export-pdf=` → `--export-filename=`) was already fixed in the examples and README. This applies the remaining suggestion from the issue: add `--export-text-to-path` to the Inkscape conversion rule.

Without it, text in the converted PDF is garbled when Inkscape does not have the same fonts PlantUML used in the SVG. Exporting text as vector paths bakes the glyphs in, making the rendering font-independent and portable.

Changed the rule in all three SVG examples and the README snippet:

```latex
\epstopdfDeclareGraphicsRule{.svg}{pdf}{.pdf}{%
  inkscape "#1" --export-text-to-path --export-filename="\OutputFile"
}
```

Trade-off: text in the resulting PDF becomes vector outlines (not selectable/searchable), which matches the examples' "include the SVG as is" approach.

The `Check` and `Release` workflows compile these SVG examples with real Inkscape, so CI exercises the new rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
