### PR TITLE
Support rendering png/svg via a PlantUML server (#6)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -77,3 +77,55 @@ jobs:
         with:
           name: output-directory-${{ matrix.engine }}
           path: out/*.pdf
+  server:
+    # Regression test for #6: render diagrams through a PlantUML server instead of
+    # a local plantuml.jar. A plantuml-server container provides the HTTP API and
+    # PLANTUML_JAR is deliberately left unset, proving the server path needs no
+    # local Java/PlantUML install. Only png and svg go through the server (the
+    # server cannot produce latex/TikZ output), so those are the examples here.
+    strategy:
+      fail-fast: false
+      matrix:
+        engine: [lualatex, pdflatex]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    services:
+      plantuml:
+        image: plantuml/plantuml-server:jetty
+        ports:
+          - 8080:8080
+    steps:
+      - uses: actions/checkout@v6
+      # inkscape converts the SVG diagram to PDF; graphviz/java are not needed
+      # locally because the server does the rendering.
+      - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
+        with:
+          packages: inkscape
+          version: 1.1
+          execute_install_scripts: true
+      - name: Install TeX Live
+        uses: zauguin/install-texlive@v4
+        with:
+          package_file: tl_packages
+      - name: Wait for the PlantUML server
+        # ~h<hex> is the encoded source "@startuml\nA->B:x\n@enduml\n".
+        run: |
+          for i in $(seq 1 60); do
+            code=$(curl -s -o /dev/null -w "%{http_code}" \
+              "http://localhost:8080/svg/~h407374617274756d6c0a412d3e423a780a40656e64756d6c0a" || true)
+            [ "$code" = "200" ] && { echo "server ready"; exit 0; }
+            sleep 2
+          done
+          echo "::error::PlantUML server did not become ready"; exit 1
+      - name: Compile server examples (no PLANTUML_JAR)
+        run: |
+          for example in example-server--png example-server--svg; do
+            echo "::group::${{ matrix.engine }} $example"
+            ${{ matrix.engine }} -shell-escape -interaction=nonstopmode -halt-on-error "$example"
+            echo "::endgroup::"
+            test -f "$example.pdf" || { echo "::error::$example.pdf was not produced"; exit 1; }
+          done
+      - uses: actions/upload-artifact@v7
+        with:
+          name: server-${{ matrix.engine }}
+          path: example-server--*.pdf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Added support for `pdflatex`. PlantUML is now driven directly via shell escape, mirroring the LuaLaTeX path (same `plantuml.jar` invocation and MD5-based source caching). [#1](https://github.com/koppor/plantuml/issues/1)
 - Added [architecture decision record 0001](docs/decisions/0001-support-pdflatex-via-shell-escape.md) explaining why pdfLaTeX is driven via shell escape rather than via `hvextern`, `pythontex`, or `bashful`. [#1](https://github.com/koppor/plantuml/issues/1)
 - Added `example-class-visibility--latex.tex`, `example-class-visibility--png.tex`, and `example-class-visibility--svg.tex` demonstrating class member visibility, including the protected marker `#`, which is written as-is (the diagram body is verbatim, so no LaTeX escaping). [#24](https://github.com/koppor/plantuml/issues/24)
+- Added support for rendering `png` and `svg` diagrams through a [PlantUML server](https://github.com/plantuml/plantuml-server) over HTTP, configured via the `server` package option or the `PLANTUML_SERVER` environment variable. This needs only `curl`, not a local `plantuml.jar`/Java, which is convenient on CI. The source is sent hex-encoded (the `~h` server marker). `latex`/TikZ output cannot be produced by a server and continues to use the local jar. Includes `example-server--png.tex` and `example-server--svg.tex`. [#6](https://github.com/koppor/plantuml/issues/6)
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,10 @@ update all of them to the same value. Pick a version from
 <https://github.com/plantuml/plantuml/releases>.
 
 - **`check.yml`** compiles the examples with `-output-directory` (regression test
-  for the pinned PlantUML).
+  for the pinned PlantUML). It also has a `server` job (regression test for #6)
+  that renders `example-server--{png,svg}` against a `plantuml/plantuml-server`
+  service container with `PLANTUML_JAR` unset; that job uses the server image's
+  own (unpinned) PlantUML, not the jar version above.
 - **`release.yml`** builds the CTAN package and GitHub Pages with the same jar.
 
 Locally, point `PLANTUML_JAR` at any jar; grab one from

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ for why pdfLaTeX is driven directly via shell escape ([issue #1](https://github.
 
 1. Environment variable `PLANTUML_JAR` set to the location of `plantuml.jar`.
    You get it from <https://sourceforge.net/projects/plantuml/files/plantuml.jar/download>.
+   Not needed when rendering `png`/`svg` through a PlantUML server (see
+   [Rendering via a PlantUML server](#rendering-via-a-plantuml-server)).
 2. Windows: Environment variable `GRAPHVIZ_DOT` set to the location of `dot.exe`.
    Example: `C:\Program Files (x86)\Graphviz2.38\bin\dot.exe`.
    You can install graphviz using `choco install graphviz`.
@@ -99,6 +101,43 @@ Car -- Person : < owns
 **Result:**
 
 ![Class relations rendered using SVG](example-class-relations--svg.png)
+
+### Rendering via a PlantUML server
+
+Instead of a local `plantuml.jar`, `png` and `svg` diagrams can be rendered by a
+[PlantUML server](https://github.com/plantuml/plantuml-server) over HTTP. This
+needs only `curl` — no Java and no local PlantUML installation — which is handy
+on CI and shared build machines (see [issue #6](https://github.com/koppor/plantuml/issues/6)).
+
+Point the package at a server with the `server` option:
+
+```latex
+\usepackage[output=svg, server=https://www.plantuml.com/plantuml]{plantuml}
+```
+
+Alternatively set the `PLANTUML_SERVER` environment variable (the package option
+takes precedence over it):
+
+```sh
+export PLANTUML_SERVER=https://www.plantuml.com/plantuml
+```
+
+You can run your own server, for example with Docker:
+
+```sh
+docker run -d -p 8080:8080 plantuml/plantuml-server:jetty
+# then use server=http://localhost:8080
+```
+
+Notes:
+
+- Only `output=png` and `output=svg` use the server. `output=latex` (TikZ, the
+  default) cannot be produced by a server and always uses the local
+  `plantuml.jar`, so keep `PLANTUML_JAR` set if you need latex output.
+- See [`example-server--png.tex`](example-server--png.tex) and
+  [`example-server--svg.tex`](example-server--svg.tex) for complete examples.
+- The diagram source is sent hex-encoded in the request URL, so a very large
+  diagram may hit the server's URL-length limit.
 
 ## Installation
 

--- a/example-server--png.tex
+++ b/example-server--png.tex
@@ -1,0 +1,20 @@
+% Renders a diagram through a PlantUML *server* instead of a local plantuml.jar,
+% so no Java/PlantUML installation is needed -- only curl. See #6.
+%
+% The `server` option below points at a local server (e.g. the official
+% `plantuml/plantuml-server` Docker image on port 8080). To use the public
+% server instead, set it to https://www.plantuml.com/plantuml. Alternatively,
+% drop the option and set the PLANTUML_SERVER environment variable.
+%
+% Only png and svg work via a server; latex/TikZ output always uses the jar.
+% PNG output needs neither inkscape nor xelatex.
+\documentclass{scrartcl}
+\usepackage[output=png, server=http://localhost:8080]{plantuml}
+\begin{document}
+\begin{plantuml}
+@startuml
+Alice -> Bob: Authentication Request
+Bob --> Alice: Authentication Response
+@enduml
+\end{plantuml}
+\end{document}

--- a/example-server--svg.tex
+++ b/example-server--svg.tex
@@ -1,0 +1,30 @@
+% Renders a diagram through a PlantUML *server* instead of a local plantuml.jar,
+% so no Java/PlantUML installation is needed -- only curl (and inkscape to turn
+% the SVG into a PDF). See #6.
+%
+% The `server` option below points at a local server (e.g. the official
+% `plantuml/plantuml-server` Docker image on port 8080). To use the public
+% server instead, set it to https://www.plantuml.com/plantuml. Alternatively,
+% drop the option and set the PLANTUML_SERVER environment variable.
+%
+% Only png and svg work via a server; latex/TikZ output always uses the jar.
+\documentclass{scrartcl}
+
+\usepackage{graphics}
+\usepackage{epstopdf}
+\epstopdfDeclareGraphicsRule{.svg}{pdf}{.pdf}{%
+  inkscape "#1" --export-text-to-path --export-filename="\OutputFile"
+}
+
+\usepackage[output=svg, server=http://localhost:8080]{plantuml}
+\begin{document}
+\begin{plantuml}
+@startuml
+class Car
+
+Driver - Car : drives >
+Car *- Wheel : have 4 >
+Car -- Person : < owns
+@enduml
+\end{plantuml}
+\end{document}

--- a/plantuml.lua
+++ b/plantuml.lua
@@ -2,14 +2,31 @@
 
 require "lfs"
 
+-- Hex-encode a string. Used to build PlantUML server URLs with the "~h" marker,
+-- which lets us avoid the deflate-based PlantUML text encoding (that would need a
+-- compression library not available in plain Lua). (#6)
+local function plantUmlHexEncode(data)
+  return (data:gsub(".", function(c) return string.format("%02x", string.byte(c)) end))
+end
+
 -- @param mode directly passed to PlantUML. Recommended: png, svg, pdf (requires Apache Batik to convert svg to pdf)
 -- @param iodir directory prefix (with trailing slash) where the generated
 --   *-plantuml.* files live. Empty unless lualatex runs with -output-directory:
 --   LaTeX redirects its writes there, but this script (a shell-escape
 --   subprocess) runs in the real working directory, so it must reach in
 --   explicitly. See plantuml.sty for how the prefix is determined (#27).
-function convertPlantUmlToTikz(jobname, mode, iodir)
+-- @param server PlantUML server base URL, e.g. https://www.plantuml.com/plantuml.
+--   When set (package option `server`, or the PLANTUML_SERVER environment
+--   variable as a fallback), png and svg diagrams are fetched from the server via
+--   curl instead of running plantuml.jar locally. The server cannot produce
+--   latex/TikZ output, so latex always uses the local jar. (#6)
+function convertPlantUmlToTikz(jobname, mode, iodir, server)
   iodir = iodir or ""
+  server = server or ""
+  if server == "" then server = os.getenv("PLANTUML_SERVER") or "" end
+  while server:sub(-1) == "/" do server = server:sub(1, -2) end
+  local useServer = (server ~= "") and (mode == "png" or mode == "svg")
+
   local plantUmlSourceFilename = iodir .. jobname .. "-plantuml.txt"
   local plantUmlTargetFilename = iodir .. jobname .. "-plantuml." .. mode
 
@@ -18,10 +35,13 @@ function convertPlantUmlToTikz(jobname, mode, iodir)
     return
   end
 
-  local plantUmlJar = os.getenv("PLANTUML_JAR")
-  if not plantUmlJar then
-    texio.write_nl("Environment variable PLANTUML_JAR not set.")
-    return
+  local plantUmlJar
+  if not useServer then
+    plantUmlJar = os.getenv("PLANTUML_JAR")
+    if not plantUmlJar then
+      texio.write_nl("Environment variable PLANTUML_JAR not set.")
+      return
+    end
   end
 
   -- check if plantUmlSourceFilename is the same as sourceCacheFilename, if yes, skip executing PlantUML
@@ -50,26 +70,38 @@ function convertPlantUmlToTikz(jobname, mode, iodir)
   os.remove(plantUmlTargetFilename)
 
   texio.write("Executing PlantUML... ")
-  local cmd = "java -Djava.awt.headless=true -jar " .. plantUmlJar .. " -charset UTF-8 -pipe -t"
-  if (mode == "latex") then
-    cmd = cmd .. "latex:nopreamble"
-    -- plantuml has changed output format in https://github.com/plantuml/plantuml/pull/1237
-    plantUmlTargetFilename = iodir .. jobname .. "-plantuml.tex"
+  local cmd
+  if useServer then
+    -- Fetch the diagram from the PlantUML server: GET <server>/<format>/~h<hex>.
+    local sourceHandle = io.open(plantUmlSourceFilename, "rb")
+    if not sourceHandle then
+      texio.write_nl("Error: Could not open source file for reading.")
+      return
+    end
+    local sourceContent = sourceHandle:read("*a")
+    io.close(sourceHandle)
+    local url = server .. "/" .. mode .. "/~h" .. plantUmlHexEncode(sourceContent)
+    cmd = [[curl -sS -f -o "]] .. plantUmlTargetFilename .. [[" "]] .. url .. [["]]
   else
-    cmd = cmd .. mode
-  end
-
-
-  cmd = cmd .. [[ < "]] .. plantUmlSourceFilename .. [[" > "]] .. plantUmlTargetFilename .. [["]]
-  -- PlantUML's TikZ output runs xelatex internally to measure text, and that
-  -- xelatex hangs when TEXMF_OUTPUT_DIRECTORY holds a relative path (set by
-  -- lualatex's -output-directory). Clear it for the PlantUML child via a command
-  -- prefix -- os.setenv is not reliable for io.popen children across builds. (#27)
-  if os.getenv("TEXMF_OUTPUT_DIRECTORY") then
-    if package.config:sub(1, 1) == "\\" then
-      cmd = [[set "TEXMF_OUTPUT_DIRECTORY=" && ]] .. cmd
+    cmd = "java -Djava.awt.headless=true -jar " .. plantUmlJar .. " -charset UTF-8 -pipe -t"
+    if (mode == "latex") then
+      cmd = cmd .. "latex:nopreamble"
+      -- plantuml has changed output format in https://github.com/plantuml/plantuml/pull/1237
+      plantUmlTargetFilename = iodir .. jobname .. "-plantuml.tex"
     else
-      cmd = "env -u TEXMF_OUTPUT_DIRECTORY " .. cmd
+      cmd = cmd .. mode
+    end
+    cmd = cmd .. [[ < "]] .. plantUmlSourceFilename .. [[" > "]] .. plantUmlTargetFilename .. [["]]
+    -- PlantUML's TikZ output runs xelatex internally to measure text, and that
+    -- xelatex hangs when TEXMF_OUTPUT_DIRECTORY holds a relative path (set by
+    -- lualatex's -output-directory). Clear it for the PlantUML child via a command
+    -- prefix -- os.setenv is not reliable for io.popen children across builds. (#27)
+    if os.getenv("TEXMF_OUTPUT_DIRECTORY") then
+      if package.config:sub(1, 1) == "\\" then
+        cmd = [[set "TEXMF_OUTPUT_DIRECTORY=" && ]] .. cmd
+      else
+        cmd = "env -u TEXMF_OUTPUT_DIRECTORY " .. cmd
+      end
     end
   end
   texio.write_nl(cmd)
@@ -83,9 +115,11 @@ function convertPlantUmlToTikz(jobname, mode, iodir)
 
   if not (lfs.attributes(plantUmlTargetFilename)) then
     texio.write_nl("PlantUML did not generate anything.")
-    handle = io.open(plantUmlTargetFilename, "w")
-    handle:write("Error during latex code generation")
-    io.close(handle)
+    if mode == "latex" then
+      handle = io.open(plantUmlTargetFilename, "w")
+      handle:write("Error during latex code generation")
+      io.close(handle)
+    end
     return
   else
     -- cache plantUmlSourceFilename for next run

--- a/plantuml.sty
+++ b/plantuml.sty
@@ -46,12 +46,17 @@
 \def\PlantUMLJobname{\myjobname\thePlantUmlFigureNumberSVG}
 
 \ExplSyntaxOn
+\tl_new:N \l_plantuml_server
 \keys_define:nn { plantuml } {
   output .choices:nn = {
     {latex, png, svg}
     { \tl_gset:NV \l_plantuml_mode \l_keys_choice_tl }
   },
-  output .initial:n = latex
+  output .initial:n = latex,
+  % PlantUML server base URL, e.g. https://www.plantuml.com/plantuml. When set,
+  % png/svg diagrams are rendered by the server instead of the local jar (#6).
+  server .tl_gset:N = \l_plantuml_server,
+  server .initial:n = ,
 }
 \ProcessKeysOptions { plantuml }
 \ExplSyntaxOff
@@ -63,6 +68,7 @@
 
 \ExplSyntaxOn
 \let\PlantUmlMode\l_plantuml_mode
+\let\PlantUmlServer\l_plantuml_server
 \ExplSyntaxOff
 
 % PlantUML runs as a shell-escape subprocess, which executes in the real
@@ -151,6 +157,11 @@
   \newwrite\plantuml@cacheout
   \let\plantuml@jar\@empty
 
+  % The PlantUML server expects hex-encoded source after a "~h" marker. "~" is an
+  % active character in TeX (\nobreakspace), so capture a catcode-12 "~h" literal
+  % for safe use inside the \edef that builds the curl URL. (#6)
+  {\catcode`\~=12 \gdef\plantuml@hexmarker{~h}}
+
   % \plantuml@readline{<file>}{<cs>}: define <cs> (globally) to the first line of
   % <file>, or to empty if the file is absent. \endlinechar=-1 strips the EOL.
   \newcommand{\plantuml@readline}[2]{%
@@ -183,7 +194,46 @@
       \closein\plantuml@stream
     \endgroup
     \ifx\plantuml@jar\@empty
-      \PackageWarning{plantuml}{Environment variable PLANTUML_JAR not set}%
+      % A PlantUML server (if configured) renders png/svg without the jar, so
+      % only warn about a missing jar when no server is set (#6).
+      \edef\plantuml@tmp{\PlantUmlServer}%
+      \ifx\plantuml@tmp\@empty
+        \PackageWarning{plantuml}{Environment variable PLANTUML_JAR not set}%
+      \fi
+    \fi
+  }
+
+  % Strip a trailing slash from \PlantUmlServer so "/<format>/~h..." appends
+  % cleanly. Defined under \ExplSyntaxOn so the l3regex name tokenizes correctly,
+  % under a letters-only name so it stays callable from normal catcodes. (#6)
+  \ExplSyntaxOn
+  \cs_new_protected:Npn \PlantumlStripTrailingSlash {
+    \regex_replace_once:nnN { /+ \Z } { } \PlantUmlServer
+  }
+  \ExplSyntaxOff
+
+  % \plantuml@readserver: resolve the PlantUML server URL. Uses the package option
+  % value if given, else the PLANTUML_SERVER environment variable (read via
+  % kpsewhich, like the jar). Any trailing slash is stripped so the format/source
+  % can be appended cleanly. Needs shell escape (for the kpsewhich pipe). (#6)
+  \newcommand*{\plantuml@readserver}{%
+    \edef\plantuml@tmp{\PlantUmlServer}%
+    \ifx\plantuml@tmp\@empty
+      \begingroup
+        \endlinechar=-1\relax
+        \openin\plantuml@stream=|"kpsewhich --var-value=PLANTUML_SERVER"\relax
+        \ifeof\plantuml@stream
+          \global\let\PlantUmlServer\@empty
+        \else
+          \readline\plantuml@stream to \plantuml@line
+          \global\let\PlantUmlServer\plantuml@line
+        \fi
+        \closein\plantuml@stream
+      \endgroup
+    \fi
+    \edef\plantuml@tmp{\PlantUmlServer}%
+    \ifx\plantuml@tmp\@empty\else
+      \PlantumlStripTrailingSlash
     \fi
   }
 
@@ -224,19 +274,39 @@
       }%
       \edef\plantuml@cache{\plantuml@src.#2.cache}%
       \IfFileExists{\plantuml@src}{%
-        \ifx\plantuml@jar\@empty
-          \PackageWarning{plantuml}{PLANTUML_JAR not set; cannot run PlantUML}%
+        % Pick the backend: a configured server renders png/svg; latex (TikZ),
+        % which the server cannot produce, and the no-server case use the jar (#6).
+        \edef\plantuml@tmp{\PlantUmlServer}%
+        \def\plantuml@useserver{0}%
+        \ifx\plantuml@tmp\@empty\else
+          \ifthenelse{\equal{#2}{latex}}{}{\def\plantuml@useserver{1}}%
+        \fi
+        \edef\plantuml@srcsum{\pdf@filemdfivesum{\plantuml@src}}%
+        \plantuml@readline{\plantuml@cache}{\plantuml@cachedsum}%
+        \ifnum\pdf@strcmp{\plantuml@srcsum}{\plantuml@cachedsum}=0\relax
+          \typeout{[plantuml] \plantuml@src\space unchanged; skipping PlantUML.}%
         \else
-          \edef\plantuml@srcsum{\pdf@filemdfivesum{\plantuml@src}}%
-          \plantuml@readline{\plantuml@cache}{\plantuml@cachedsum}%
-          \ifnum\pdf@strcmp{\plantuml@srcsum}{\plantuml@cachedsum}=0\relax
-            \typeout{[plantuml] \plantuml@src\space unchanged; skipping PlantUML.}%
-          \else
+          \let\plantuml@cmd\@empty
+          \ifthenelse{\equal{\plantuml@useserver}{1}}{%
+            % Server backend: GET <server>/<format>/~h<hex-source> via curl.
+            % \pdf@filedump emits the file as (uppercase) hex, which the server
+            % accepts after the ~h marker.
+            \edef\plantuml@hex{\pdf@filedump{0}{\pdf@filesize{\PlantUmlIODir\plantuml@src}}{\PlantUmlIODir\plantuml@src}}%
             \edef\plantuml@cmd{%
-              \PlantUmlEnvReset
-              java -Djava.awt.headless=true -jar "\plantuml@jar"%
-              \space -charset UTF-8 -pipe -t\plantuml@topt
-              \space < "\PlantUmlIODir\plantuml@src" > "\PlantUmlIODir\plantuml@tgt"}%
+              curl -sS -f -o "\PlantUmlIODir\plantuml@tgt"%
+              \space "\PlantUmlServer/\plantuml@topt/\plantuml@hexmarker\plantuml@hex"}%
+          }{%
+            \ifx\plantuml@jar\@empty
+              \PackageWarning{plantuml}{PLANTUML_JAR not set; cannot run PlantUML}%
+            \else
+              \edef\plantuml@cmd{%
+                \PlantUmlEnvReset
+                java -Djava.awt.headless=true -jar "\plantuml@jar"%
+                \space -charset UTF-8 -pipe -t\plantuml@topt
+                \space < "\PlantUmlIODir\plantuml@src" > "\PlantUmlIODir\plantuml@tgt"}%
+            \fi
+          }%
+          \ifx\plantuml@cmd\@empty\else
             \typeout{[plantuml] \plantuml@cmd}%
             \immediate\write18{\plantuml@cmd}%
             \IfFileExists{\PlantUmlIODir\plantuml@tgt}{%
@@ -270,11 +340,14 @@
   \ifluatex
     \directlua{
       local plantUmlJar = os.getenv("PLANTUML_JAR")
-      if not plantUmlJar then
+      local server = \luastring{\PlantUmlServer}
+      if server == "" then server = os.getenv("PLANTUML_SERVER") or "" end
+      if not plantUmlJar and server == "" then
         texio.write_nl("Environment variable PLANTUML_JAR not set.")
       end
     }
   \else
+    \plantuml@readserver
     \plantuml@readjar
     \plantuml@readoutdir
   \fi
@@ -287,8 +360,9 @@
         local jobname=\luastring{\PlantUMLJobname}
         local plantUmlMode=\luastring{\PlantUmlMode}
         local plantUmlIODir=\luastring{\PlantUmlIODir}
+        local plantUmlServer=\luastring{\PlantUmlServer}
         require("plantuml.lua")
-        convertPlantUmlToTikz(jobname, plantUmlMode, plantUmlIODir)
+        convertPlantUmlToTikz(jobname, plantUmlMode, plantUmlIODir, plantUmlServer)
       }
     \else
       \plantuml@convert{\PlantUMLJobname}{\PlantUmlMode}


### PR DESCRIPTION
Closes #6.

Render `png`/`svg` diagrams through a [PlantUML server](https://github.com/plantuml/plantuml-server) over HTTP instead of a local `plantuml.jar` — no Java/PlantUML install needed, only `curl`. Useful for CI and shared build machines (the original use case in #6).

## How it works

- New `server` package option, e.g. `\usepackage[output=svg, server=https://www.plantuml.com/plantuml]{plantuml}`, with a `PLANTUML_SERVER` environment-variable fallback (the option wins).
- The diagram source is sent **hex-encoded** using the server's `~h` marker (`GET <server>/<format>/~h<hex>`). This avoids the deflate-based PlantUML text encoding, which would need a compression library not available in plain Lua/TeX.
- Both engines covered:
  - **LuaTeX** (`plantuml.lua`): hex-encodes the source and `curl`s the server.
  - **pdfTeX** (`plantuml.sty`): same, using `\pdf@filedump` for the hex and a catcode-12 `~h` literal (since `~` is active in TeX).
- The existing MD5/source caching is preserved for the server backend too.

## Scope / limitations

- Only `output=png` and `output=svg` use the server. `output=latex` (TikZ, the default) **cannot** be produced by a PlantUML server (the public server returns HTTP 500; the `:nopreamble` variant isn't URL-addressable), so latex always falls back to the local jar. Keep `PLANTUML_JAR` set if you need latex output.
- The source travels in the request URL, so very large diagrams can hit the server's URL-length limit.

## Testing

Validated end-to-end in Docker against a local `plantuml/plantuml-server:jetty` container with **`PLANTUML_JAR` unset**:

- `png` and `svg`, both `lualatex` and `pdflatex` → real diagrams render (visually verified).
- Trailing-slash server URLs and the `PLANTUML_SERVER` env-var fallback are normalized correctly.
- With a server **and** a jar set, `output=latex` correctly uses the jar (`[plantuml] java`, never `curl`).

CI: a new `server` job in `check.yml` runs a `plantuml-server` service container and compiles `example-server--{png,svg}.tex` with both engines, `PLANTUML_JAR` unset. The job uses the server image's own (unpinned) PlantUML, independent of the pinned jar version.

`CHANGELOG.md` passes `heylogs check`.