### PR TITLE
Typeset a placeholder instead of failing when a diagram can't be generated (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Added `example-class-visibility--latex.tex`, `example-class-visibility--png.tex`, and `example-class-visibility--svg.tex` demonstrating class member visibility, including the protected marker `#`, which is written as-is (the diagram body is verbatim, so no LaTeX escaping). [#24](https://github.com/koppor/plantuml/issues/24)
 - Added support for rendering `png` and `svg` diagrams through a [PlantUML server](https://github.com/plantuml/plantuml-server) over HTTP, configured via the `server` package option or the `PLANTUML_SERVER` environment variable. This needs only `curl`, not a local `plantuml.jar`/Java, which is convenient on CI. The source is sent hex-encoded (the `~h` server marker). `latex`/TikZ output cannot be produced by a server and continues to use the local jar. Includes `example-server--png.tex` and `example-server--svg.tex`. [#6](https://github.com/koppor/plantuml/issues/6)
 
+### Changed
+
+- A diagram that cannot be generated (for example when `PLANTUML_JAR` is not set, no server is configured, or PlantUML fails) no longer aborts the LaTeX run. A visible placeholder is typeset in the document instead, similar to a missing reference. [#16](https://github.com/koppor/plantuml/issues/16)
+
 ### Fixed
 
 - Fixed `lualatex` failing with `I can't write on file '…-plantuml.txt'` under the paranoid `openout_any=p` setting (the default of local TeX Live and MiKTeX installations). The generated source file is now written with a relative path whenever possible, falling back to the absolute working directory only when the write is redirected (e.g. by Overleaf's output directory), so the Overleaf fix keeps working. [#47](https://github.com/koppor/plantuml/issues/47), [#50](https://github.com/koppor/plantuml/issues/50), [#42](https://github.com/koppor/plantuml/pull/42)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ for why pdfLaTeX is driven directly via shell escape ([issue #1](https://github.
    You get it from <https://sourceforge.net/projects/plantuml/files/plantuml.jar/download>.
    Not needed when rendering `png`/`svg` through a PlantUML server (see
    [Rendering via a PlantUML server](#rendering-via-a-plantuml-server)).
+   If neither a jar nor a server is available, the diagram is replaced by a
+   visible placeholder rather than aborting the build.
 2. Windows: Environment variable `GRAPHVIZ_DOT` set to the location of `dot.exe`.
    Example: `C:\Program Files (x86)\Graphviz2.38\bin\dot.exe`.
    You can install graphviz using `choco install graphviz`.

--- a/plantuml.lua
+++ b/plantuml.lua
@@ -114,12 +114,9 @@ function convertPlantUmlToTikz(jobname, mode, iodir, server)
   io.close(handle)
 
   if not (lfs.attributes(plantUmlTargetFilename)) then
+    -- Leave no target file: plantuml.sty then typesets a visible placeholder
+    -- instead of failing on a missing \input/\includegraphics. (#16)
     texio.write_nl("PlantUML did not generate anything.")
-    if mode == "latex" then
-      handle = io.open(plantUmlTargetFilename, "w")
-      handle:write("Error during latex code generation")
-      io.close(handle)
-    end
     return
   else
     -- cache plantUmlSourceFilename for next run

--- a/plantuml.sty
+++ b/plantuml.sty
@@ -145,6 +145,24 @@
 
 \makeatletter
 
+% \plantuml@notgenerated: visible, non-fatal placeholder typeset in the document
+% when a diagram could not be generated (e.g. PLANTUML_JAR unset, no server, or
+% PlantUML failed). This keeps compilation going -- the error is shown in the
+% output, similar to a missing reference -- instead of aborting on a missing
+% \input/\includegraphics. (#16)
+\newcommand{\plantuml@notgenerated}{%
+  \PackageWarning{plantuml}{PlantUML diagram could not be generated; is
+    PLANTUML_JAR set (or a server configured) and -shell-escape enabled?}%
+  \fbox{%
+    \begin{minipage}{0.8\linewidth}%
+      \raggedright
+      \textbf{PlantUML diagram could not be generated.}\par
+      Ensure \texttt{PLANTUML\_JAR} is set (or a \texttt{server} is configured)
+      and that \texttt{-shell-escape} is enabled.%
+    \end{minipage}%
+  }%
+}
+
 % --- Non-Lua (e.g. pdflatex) PlantUML driver ----------------------------------
 % The LuaTeX path (plantuml.lua) shells out with io.popen, reads PLANTUML_JAR
 % with os.getenv and checks files with lfs. For pdfTeX we reproduce the same
@@ -368,11 +386,19 @@
       \plantuml@convert{\PlantUMLJobname}{\PlantUmlMode}
     \fi
     \ifthenelse{\equal{\PlantUmlMode}{latex}}{
-      \begin{adjustbox}{max width=\linewidth}
-        \input{\PlantUmlIODir\PlantUMLJobname-plantuml.tex}
-      \end{adjustbox}
+      \IfFileExists{\PlantUmlIODir\PlantUMLJobname-plantuml.tex}{%
+        \begin{adjustbox}{max width=\linewidth}
+          \input{\PlantUmlIODir\PlantUMLJobname-plantuml.tex}
+        \end{adjustbox}%
+      }{%
+        \plantuml@notgenerated
+      }%
     }{
-      \includegraphics[width=\maxwidth{\textwidth}]{\PlantUmlIODir\PlantUMLJobname-plantuml.\PlantUmlMode}
+      \IfFileExists{\PlantUmlIODir\PlantUMLJobname-plantuml.\PlantUmlMode}{%
+        \includegraphics[width=\maxwidth{\textwidth}]{\PlantUmlIODir\PlantUMLJobname-plantuml.\PlantUmlMode}%
+      }{%
+        \plantuml@notgenerated
+      }%
       \UMLcountUp
     }
   }


### PR DESCRIPTION
Closes #16.

When PlantUML can't produce a diagram — `PLANTUML_JAR` unset, no server configured, or PlantUML failed — the build no longer aborts. Instead a visible placeholder is typeset in the document and a package warning is emitted, so compilation continues and the error is visible in the output (analogous to a missing reference).

### Before
The missing `\input{…-plantuml.tex}` / `\includegraphics{…}` raised a fatal "file not found" error and stopped the build.

### After
Both inclusions are guarded with `\IfFileExists`; when the target is absent, `\plantuml@notgenerated` typesets:

> **PlantUML diagram could not be generated.**
> Ensure `PLANTUML_JAR` is set (or a `server` is configured) and that `-shell-escape` is enabled.

Also removes `plantuml.lua`'s now-redundant `"Error during latex code generation"` fallback file, so every failure mode shows the same placeholder rather than raw text.

### Testing (Docker, both engines)

- **No `PLANTUML_JAR`, no server** (latex and png modes): compiles successfully (exit 0, PDF produced) with the placeholder shown — verified visually.
- **Happy path** (server reachable): the real diagram is still included, no placeholder, no warning.

`CHANGELOG.md` passes `heylogs check`.