### PR TITLE
Cache generated diagrams by content hash (minted/memoize style) (#2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 *-plantuml.*
+# content-addressed PlantUML cache files (#2)
+plantuml-*.tex
+plantuml-*.png
+plantuml-*.svg
 *.pdf
 tmp-pdfcrop-*.tex
 tex2pdf.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,4 @@
 *-plantuml.*
-# content-addressed PlantUML cache files (#2)
-plantuml-*.tex
-plantuml-*.png
-plantuml-*.svg
 *.pdf
 tmp-pdfcrop-*.tex
 tex2pdf.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Generated diagrams are now cached by a content hash (minted/memoize style): each diagram is written to `plantuml-<md5>.<ext>` and PlantUML (or the server) is invoked only when no file for that hash exists yet. Identical, repeated, or reordered diagrams reuse the cached output, so recompiles are fast and only edited diagrams are regenerated. [#2](https://github.com/koppor/plantuml/issues/2)
 - A diagram that cannot be generated (for example when `PLANTUML_JAR` is not set, no server is configured, or PlantUML fails) no longer aborts the LaTeX run. A visible placeholder is typeset in the document instead, similar to a missing reference. [#16](https://github.com/koppor/plantuml/issues/16)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- Generated diagrams are now cached by a content hash (minted/memoize style): each diagram is written to `plantuml-<md5>.<ext>` and PlantUML (or the server) is invoked only when no file for that hash exists yet. Identical, repeated, or reordered diagrams reuse the cached output, so recompiles are fast and only edited diagrams are regenerated. [#2](https://github.com/koppor/plantuml/issues/2)
+- Generated diagrams are now cached by a content hash (minted/memoize style): each diagram is written to `plantuml-<md5>-converted-to.<ext>` and PlantUML (or the server) is invoked only when no file for that hash exists yet. Identical, repeated, or reordered diagrams reuse the cached output, so recompiles are fast and only edited diagrams are regenerated. The `-converted-to` suffix keeps the files covered by the standard TeX `.gitignore` (`*-converted-to.*`), so no extra ignore entry is needed. [#2](https://github.com/koppor/plantuml/issues/2)
 - A diagram that cannot be generated (for example when `PLANTUML_JAR` is not set, no server is configured, or PlantUML fails) no longer aborts the LaTeX run. A visible placeholder is typeset in the document instead, similar to a missing reference. [#16](https://github.com/koppor/plantuml/issues/16)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -141,6 +141,17 @@ Notes:
 - The diagram source is sent hex-encoded in the request URL, so a very large
   diagram may hit the server's URL-length limit.
 
+### Caching
+
+Generated diagrams are cached by a hash of their source, similar to
+[minted](https://www.ctan.org/pkg/minted) and
+[memoize](https://www.ctan.org/pkg/memoize). Each diagram is written to
+`plantuml-<hash>.<ext>`, and PlantUML (or the server) is invoked only when no
+file for that hash exists yet. Unchanged diagrams — as well as repeated or
+reordered ones — reuse the cached output, so recompiles are fast and only edited
+diagrams are regenerated. Delete the `plantuml-*.{tex,png,svg}` files to clear
+the cache.
+
 ## Installation
 
 Your latex distribution should take care.

--- a/README.md
+++ b/README.md
@@ -146,11 +146,13 @@ Notes:
 Generated diagrams are cached by a hash of their source, similar to
 [minted](https://www.ctan.org/pkg/minted) and
 [memoize](https://www.ctan.org/pkg/memoize). Each diagram is written to
-`plantuml-<hash>.<ext>`, and PlantUML (or the server) is invoked only when no
-file for that hash exists yet. Unchanged diagrams — as well as repeated or
-reordered ones — reuse the cached output, so recompiles are fast and only edited
-diagrams are regenerated. Delete the `plantuml-*.{tex,png,svg}` files to clear
-the cache.
+`plantuml-<hash>-converted-to.<ext>`, and PlantUML (or the server) is invoked
+only when no file for that hash exists yet. Unchanged diagrams — as well as
+repeated or reordered ones — reuse the cached output, so recompiles are fast and
+only edited diagrams are regenerated. The `-converted-to` suffix means the
+standard [TeX `.gitignore`](https://github.com/github/gitignore/blob/main/TeX.gitignore)
+already ignores these files (via `*-converted-to.*`), so no extra entry is
+needed. Delete the `plantuml-*-converted-to.*` files to clear the cache.
 
 ## Installation
 

--- a/plantuml.lua
+++ b/plantuml.lua
@@ -20,6 +20,8 @@ end
 --   variable as a fallback), png and svg diagrams are fetched from the server via
 --   curl instead of running plantuml.jar locally. The server cannot produce
 --   latex/TikZ output, so latex always uses the local jar. (#6)
+-- @return the content hash of the diagram (so plantuml.sty can include the
+--   hash-named output file), or nil if the diagram could not be generated.
 function convertPlantUmlToTikz(jobname, mode, iodir, server)
   iodir = iodir or ""
   server = server or ""
@@ -28,11 +30,38 @@ function convertPlantUmlToTikz(jobname, mode, iodir, server)
   local useServer = (server ~= "") and (mode == "png" or mode == "svg")
 
   local plantUmlSourceFilename = iodir .. jobname .. "-plantuml.txt"
-  local plantUmlTargetFilename = iodir .. jobname .. "-plantuml." .. mode
 
   if not (lfs.attributes(plantUmlSourceFilename)) then
     texio.write_nl("Source " .. plantUmlSourceFilename .. " does not exist.")
-    return
+    return nil
+  end
+
+  -- Read the source and content-address the output by its hash, minted/memoize
+  -- style: identical (or reordered) diagrams reuse the cached file and PlantUML
+  -- is run only when no matching output exists yet. (#2)
+  local sourceHandle = io.open(plantUmlSourceFilename, "rb")
+  if not sourceHandle then
+    texio.write_nl("Error: Could not open source file for reading.")
+    return nil
+  end
+  local sourceContent = sourceHandle:read("*a")
+  io.close(sourceHandle)
+
+  local md5lib = md5 or require("md5")
+  -- uppercase to match pdfTeX's \pdf@filemdfivesum, so both engines name the
+  -- cache file identically for the same diagram (#2).
+  local hash = md5lib.sumhexa(sourceContent):upper()
+  local ext = (mode == "latex") and "tex" or mode
+  local plantUmlTargetFilename = iodir .. "plantuml-" .. hash .. "." .. ext
+
+  -- A non-empty output for this hash means the diagram was rendered before.
+  local function fileNonEmpty(path)
+    local a = lfs.attributes(path)
+    return a and a.size and a.size > 0
+  end
+  if fileNonEmpty(plantUmlTargetFilename) then
+    texio.write_nl("PlantUML cache hit \"" .. plantUmlTargetFilename .. "\"; skipping execution.")
+    return hash
   end
 
   local plantUmlJar
@@ -40,46 +69,14 @@ function convertPlantUmlToTikz(jobname, mode, iodir, server)
     plantUmlJar = os.getenv("PLANTUML_JAR")
     if not plantUmlJar then
       texio.write_nl("Environment variable PLANTUML_JAR not set.")
-      return
+      return nil
     end
   end
-
-  -- check if plantUmlSourceFilename is the same as sourceCacheFilename, if yes, skip executing PlantUML
-  local sourceCacheFilename = plantUmlSourceFilename .. "." .. mode .. ".cache"
-  local sourceCacheHandle = io.open(sourceCacheFilename, "r")
-  if sourceCacheHandle then
-    texio.write_nl("Cache \"" .. sourceCacheFilename .. "\" exists.")
-    local sourceCacheContent = sourceCacheHandle:read("*a")
-    io.close(sourceCacheHandle)
-
-    local sourceHandle = io.open(plantUmlSourceFilename, "r")
-    if not sourceHandle then
-      texio.write_nl("Error: Could not open source file for reading.")
-    end
-    local sourceContent = sourceHandle:read("*a")
-    io.close(sourceHandle)
-
-    if sourceContent == sourceCacheContent then
-      texio.write_nl("Source \"" .. plantUmlSourceFilename .. "\" is unchanged, skipping PlantUML execution.")
-      return
-    else
-      texio.write_nl("Source \"" .. plantUmlSourceFilename .. "\" has changed. ")
-    end
-  end
-  -- delete generated file to ensure they are really recreated
-  os.remove(plantUmlTargetFilename)
 
   texio.write("Executing PlantUML... ")
   local cmd
   if useServer then
     -- Fetch the diagram from the PlantUML server: GET <server>/<format>/~h<hex>.
-    local sourceHandle = io.open(plantUmlSourceFilename, "rb")
-    if not sourceHandle then
-      texio.write_nl("Error: Could not open source file for reading.")
-      return
-    end
-    local sourceContent = sourceHandle:read("*a")
-    io.close(sourceHandle)
     local url = server .. "/" .. mode .. "/~h" .. plantUmlHexEncode(sourceContent)
     cmd = [[curl -sS -f -o "]] .. plantUmlTargetFilename .. [[" "]] .. url .. [["]]
   else
@@ -88,8 +85,6 @@ function convertPlantUmlToTikz(jobname, mode, iodir, server)
     cmd = [[java -Djava.awt.headless=true -jar "]] .. plantUmlJar .. [[" -charset UTF-8 -pipe -t]]
     if (mode == "latex") then
       cmd = cmd .. "latex:nopreamble"
-      -- plantuml has changed output format in https://github.com/plantuml/plantuml/pull/1237
-      plantUmlTargetFilename = iodir .. jobname .. "-plantuml.tex"
     else
       cmd = cmd .. mode
     end
@@ -111,30 +106,17 @@ function convertPlantUmlToTikz(jobname, mode, iodir, server)
   if not handle then
     texio.write_nl("Error during execution of PlantUML.")
     texio.write_nl(error)
-    return
+    return nil
   end
   io.close(handle)
 
-  if not (lfs.attributes(plantUmlTargetFilename)) then
-    -- Leave no target file: plantuml.sty then typesets a visible placeholder
-    -- instead of failing on a missing \input/\includegraphics. (#16)
+  if not fileNonEmpty(plantUmlTargetFilename) then
+    -- Remove a possibly empty file (e.g. a failed shell redirect) so it is not
+    -- cached as a poisoned result, and leave no target so plantuml.sty typesets
+    -- a visible placeholder instead of failing on a missing include. (#16)
+    os.remove(plantUmlTargetFilename)
     texio.write_nl("PlantUML did not generate anything.")
-    return
-  else
-    -- cache plantUmlSourceFilename for next run
-    texio.write_nl("Caching source file \"" .. plantUmlSourceFilename .. "\" to \"" .. sourceCacheFilename .. "\".")
-    local sourceHandle = io.open(plantUmlSourceFilename, "r")
-    if sourceHandle then
-      local cacheHandle = io.open(sourceCacheFilename, "w")
-      if cacheHandle then
-      cacheHandle:write(sourceHandle:read("*a"))
-      io.close(cacheHandle)
-      else
-      texio.write_nl("Error: Could not open cache file for writing.")
-      end
-      io.close(sourceHandle)
-    else
-      texio.write_nl("Error: Could not open source file for reading.")
-    end
+    return nil
   end
+  return hash
 end

--- a/plantuml.lua
+++ b/plantuml.lua
@@ -52,7 +52,9 @@ function convertPlantUmlToTikz(jobname, mode, iodir, server)
   -- cache file identically for the same diagram (#2).
   local hash = md5lib.sumhexa(sourceContent):upper()
   local ext = (mode == "latex") and "tex" or mode
-  local plantUmlTargetFilename = iodir .. "plantuml-" .. hash .. "." .. ext
+  -- The "-converted-to." infix means the standard TeX .gitignore (*-converted-to.*)
+  -- already ignores these cache files, so users need no extra .gitignore entry (#2).
+  local plantUmlTargetFilename = iodir .. "plantuml-" .. hash .. "-converted-to." .. ext
 
   -- A non-empty output for this hash means the diagram was rendered before.
   local function fileNonEmpty(path)

--- a/plantuml.sty
+++ b/plantuml.sty
@@ -12,7 +12,8 @@
 % Enable checking for active -shell-escape
 % Source: https://tex.stackexchange.com/a/88620/9075
 % pdftexcmds also provides the engine-agnostic helpers used by the pdflatex
-% path below: \pdf@filemdfivesum, \pdf@strcmp, and \pdf@filesize.
+% path below: \pdf@filemdfivesum (content-hash cache), \pdf@filesize, and
+% \pdf@filedump (hex-encode the source for the PlantUML server).
 \RequirePackage{pdftexcmds}
 
 % Robust \ifluatex (and friends) across engines, needed to branch between the
@@ -145,6 +146,10 @@
 
 \makeatletter
 
+% Content hash of the current diagram; the generated file is plantuml-<hash>.<ext>
+% (#2). Set per diagram by the converter; default empty as a safety net.
+\newcommand{\PlantUmlHash}{}
+
 % \plantuml@notgenerated: visible, non-fatal placeholder typeset in the document
 % when a diagram could not be generated (e.g. PLANTUML_JAR unset, no server, or
 % PlantUML failed). This keeps compilation going -- the error is shown in the
@@ -172,29 +177,12 @@
 % same caching that plantuml.lua does, which avoids latexmk rebuild loops).
 \ifluatex\else
   \newread\plantuml@stream
-  \newwrite\plantuml@cacheout
   \let\plantuml@jar\@empty
 
   % The PlantUML server expects hex-encoded source after a "~h" marker. "~" is an
   % active character in TeX (\nobreakspace), so capture a catcode-12 "~h" literal
   % for safe use inside the \edef that builds the curl URL. (#6)
   {\catcode`\~=12 \gdef\plantuml@hexmarker{~h}}
-
-  % \plantuml@readline{<file>}{<cs>}: define <cs> (globally) to the first line of
-  % <file>, or to empty if the file is absent. \endlinechar=-1 strips the EOL.
-  \newcommand{\plantuml@readline}[2]{%
-    \begingroup
-      \endlinechar=-1\relax
-      \openin\plantuml@stream=#1\relax
-      \ifeof\plantuml@stream
-        \global\def#2{}%
-      \else
-        \readline\plantuml@stream to \plantuml@line
-        \global\let#2\plantuml@line
-      \fi
-      \closein\plantuml@stream
-    \endgroup
-  }
 
   % \plantuml@readjar: read the PLANTUML_JAR environment variable into
   % \plantuml@jar, cross-platform, via kpsewhich. Needs full shell escape, so it
@@ -276,34 +264,41 @@
     \endgroup
   }
 
-  % \plantuml@convert{<jobname>}{<mode>}: run PlantUML on <jobname>-plantuml.txt,
-  % producing <jobname>-plantuml.{tex|<mode>}. The run is skipped when the source
-  % is byte-for-byte identical to the previously converted one (MD5 cache).
+  % \plantuml@iffilenonempty{<file>}{<then>}{<else>}: run <then> if <file> exists
+  % and is non-empty, else <else>.
+  \newcommand{\plantuml@iffilenonempty}[3]{%
+    \IfFileExists{#1}{\ifnum\pdf@filesize{#1}>0\relax #2\else #3\fi}{#3}%
+  }
+
+  % \plantuml@convert{<jobname>}{<mode>}: render <jobname>-plantuml.txt to the
+  % content-addressed file plantuml-<md5>.{tex|<mode>}. PlantUML runs only when no
+  % such file exists yet, so identical or reordered diagrams reuse the cached
+  % output (#2). Sets \PlantUmlHash to the md5 (empty on failure) so the
+  % environment can include the matching file.
   \newcommand{\plantuml@convert}[2]{%
     \begingroup
       \edef\plantuml@src{#1-plantuml.txt}%
       \ifthenelse{\equal{#2}{latex}}{%
         % PlantUML emits the file with a .tex extension since v1.2023.0.
-        \edef\plantuml@tgt{#1-plantuml.tex}%
+        \def\plantuml@ext{tex}%
         \def\plantuml@topt{latex:nopreamble}%
       }{%
-        \edef\plantuml@tgt{#1-plantuml.#2}%
+        \def\plantuml@ext{#2}%
         \def\plantuml@topt{#2}%
       }%
-      \edef\plantuml@cache{\plantuml@src.#2.cache}%
       \IfFileExists{\plantuml@src}{%
-        % Pick the backend: a configured server renders png/svg; latex (TikZ),
-        % which the server cannot produce, and the no-server case use the jar (#6).
-        \edef\plantuml@tmp{\PlantUmlServer}%
-        \def\plantuml@useserver{0}%
-        \ifx\plantuml@tmp\@empty\else
-          \ifthenelse{\equal{#2}{latex}}{}{\def\plantuml@useserver{1}}%
-        \fi
-        \edef\plantuml@srcsum{\pdf@filemdfivesum{\plantuml@src}}%
-        \plantuml@readline{\plantuml@cache}{\plantuml@cachedsum}%
-        \ifnum\pdf@strcmp{\plantuml@srcsum}{\plantuml@cachedsum}=0\relax
-          \typeout{[plantuml] \plantuml@src\space unchanged; skipping PlantUML.}%
-        \else
+        \edef\plantuml@hash{\pdf@filemdfivesum{\plantuml@src}}%
+        \edef\plantuml@tgt{plantuml-\plantuml@hash.\plantuml@ext}%
+        \plantuml@iffilenonempty{\PlantUmlIODir\plantuml@tgt}{%
+          \typeout{[plantuml] cache hit \plantuml@tgt;\space skipping PlantUML.}%
+        }{%
+          % Pick the backend: a configured server renders png/svg; latex (TikZ),
+          % which the server cannot produce, and the no-server case use the jar (#6).
+          \edef\plantuml@tmp{\PlantUmlServer}%
+          \def\plantuml@useserver{0}%
+          \ifx\plantuml@tmp\@empty\else
+            \ifthenelse{\equal{#2}{latex}}{}{\def\plantuml@useserver{1}}%
+          \fi
           \let\plantuml@cmd\@empty
           \ifthenelse{\equal{\plantuml@useserver}{1}}{%
             % Server backend: GET <server>/<format>/~h<hex-source> via curl.
@@ -327,22 +322,21 @@
           \ifx\plantuml@cmd\@empty\else
             \typeout{[plantuml] \plantuml@cmd}%
             \immediate\write18{\plantuml@cmd}%
-            \IfFileExists{\PlantUmlIODir\plantuml@tgt}{%
-              \ifnum\pdf@filesize{\PlantUmlIODir\plantuml@tgt}>0\relax
-                % Cache the source MD5 so the next run can skip PlantUML.
-                \immediate\openout\plantuml@cacheout=\plantuml@cache\relax
-                \immediate\write\plantuml@cacheout{\plantuml@srcsum}%
-                \immediate\closeout\plantuml@cacheout
-              \else
-                \PackageWarning{plantuml}{PlantUML produced an empty \plantuml@tgt}%
-              \fi
-            }{%
+            \plantuml@iffilenonempty{\PlantUmlIODir\plantuml@tgt}{}{%
               \PackageWarning{plantuml}{PlantUML did not generate \plantuml@tgt}%
             }%
           \fi
-        \fi
+        }%
+        % Expose the hash only if a non-empty output now exists, else empty so the
+        % environment shows the missing-diagram placeholder (#16).
+        \plantuml@iffilenonempty{\PlantUmlIODir\plantuml@tgt}{%
+          \global\let\PlantUmlHash\plantuml@hash
+        }{%
+          \global\let\PlantUmlHash\@empty
+        }%
       }{%
         \PackageWarning{plantuml}{Source \plantuml@src\space does not exist}%
+        \global\let\PlantUmlHash\@empty
       }%
     \endgroup
   }
@@ -373,6 +367,8 @@
     \VerbatimOut{"\CurrentDirectory\PlantUMLJobname-plantuml.txt"}}
   {%
     \endVerbatimOut
+    % \PlantUmlHash is set to the content hash of the diagram; the generated file
+    % is named plantuml-<hash>.<ext> so identical diagrams share one cached file (#2).
     \ifluatex
       \directlua{
         local jobname=\luastring{\PlantUMLJobname}
@@ -380,22 +376,23 @@
         local plantUmlIODir=\luastring{\PlantUmlIODir}
         local plantUmlServer=\luastring{\PlantUmlServer}
         require("plantuml.lua")
-        convertPlantUmlToTikz(jobname, plantUmlMode, plantUmlIODir, plantUmlServer)
+        local hash = convertPlantUmlToTikz(jobname, plantUmlMode, plantUmlIODir, plantUmlServer)
+        tex.sprint("\\gdef\\PlantUmlHash{" .. (hash or "") .. "}")
       }
     \else
       \plantuml@convert{\PlantUMLJobname}{\PlantUmlMode}
     \fi
     \ifthenelse{\equal{\PlantUmlMode}{latex}}{
-      \IfFileExists{\PlantUmlIODir\PlantUMLJobname-plantuml.tex}{%
+      \IfFileExists{\PlantUmlIODir plantuml-\PlantUmlHash.tex}{%
         \begin{adjustbox}{max width=\linewidth}
-          \input{\PlantUmlIODir\PlantUMLJobname-plantuml.tex}
+          \input{\PlantUmlIODir plantuml-\PlantUmlHash.tex}
         \end{adjustbox}%
       }{%
         \plantuml@notgenerated
       }%
     }{
-      \IfFileExists{\PlantUmlIODir\PlantUMLJobname-plantuml.\PlantUmlMode}{%
-        \includegraphics[width=\maxwidth{\textwidth}]{\PlantUmlIODir\PlantUMLJobname-plantuml.\PlantUmlMode}%
+      \IfFileExists{\PlantUmlIODir plantuml-\PlantUmlHash.\PlantUmlMode}{%
+        \includegraphics[width=\maxwidth{\textwidth}]{\PlantUmlIODir plantuml-\PlantUmlHash.\PlantUmlMode}%
       }{%
         \plantuml@notgenerated
       }%

--- a/plantuml.sty
+++ b/plantuml.sty
@@ -288,7 +288,9 @@
       }%
       \IfFileExists{\plantuml@src}{%
         \edef\plantuml@hash{\pdf@filemdfivesum{\plantuml@src}}%
-        \edef\plantuml@tgt{plantuml-\plantuml@hash.\plantuml@ext}%
+        % The "-converted-to." infix makes these cache files match the standard
+        % TeX .gitignore pattern *-converted-to.*, so no custom entry is needed (#2).
+        \edef\plantuml@tgt{plantuml-\plantuml@hash-converted-to.\plantuml@ext}%
         \plantuml@iffilenonempty{\PlantUmlIODir\plantuml@tgt}{%
           \typeout{[plantuml] cache hit \plantuml@tgt;\space skipping PlantUML.}%
         }{%
@@ -383,16 +385,16 @@
       \plantuml@convert{\PlantUMLJobname}{\PlantUmlMode}
     \fi
     \ifthenelse{\equal{\PlantUmlMode}{latex}}{
-      \IfFileExists{\PlantUmlIODir plantuml-\PlantUmlHash.tex}{%
+      \IfFileExists{\PlantUmlIODir plantuml-\PlantUmlHash-converted-to.tex}{%
         \begin{adjustbox}{max width=\linewidth}
-          \input{\PlantUmlIODir plantuml-\PlantUmlHash.tex}
+          \input{\PlantUmlIODir plantuml-\PlantUmlHash-converted-to.tex}
         \end{adjustbox}%
       }{%
         \plantuml@notgenerated
       }%
     }{
-      \IfFileExists{\PlantUmlIODir plantuml-\PlantUmlHash.\PlantUmlMode}{%
-        \includegraphics[width=\maxwidth{\textwidth}]{\PlantUmlIODir plantuml-\PlantUmlHash.\PlantUmlMode}%
+      \IfFileExists{\PlantUmlIODir plantuml-\PlantUmlHash-converted-to.\PlantUmlMode}{%
+        \includegraphics[width=\maxwidth{\textwidth}]{\PlantUmlIODir plantuml-\PlantUmlHash-converted-to.\PlantUmlMode}%
       }{%
         \plantuml@notgenerated
       }%


### PR DESCRIPTION
Closes #2.

Introduces minted/[memoize](https://www.ctan.org/pkg/memoize)-style **content-addressed caching**.

### Before
A per-position cache stored each diagram slot's source/MD5 in a sidecar `.cache` file and skipped re-running PlantUML when *that slot* was unchanged. It sped up the edit-recompile loop but was keyed by document position, so reordering/inserting diagrams re-rendered them and identical diagrams didn't share.

### After
Each diagram is rendered to `plantuml-<md5>.<ext>`, and PlantUML (or the server) runs **only when no file for that hash exists yet**. The diagram's existence *is* the cache.

- Identical, repeated, or **reordered** diagrams share one cached file.
- Recompiling an unchanged document runs PlantUML **zero** times.
- Editing one diagram regenerates **only** that diagram.
- Both engines name the file identically (the Lua `md5.sumhexa` is uppercased to match pdfTeX's `\pdf@filemdfivesum`), so the cache is shared across `lualatex`/`pdflatex`.

The environment includes `plantuml-<hash>.<ext>`; on failure the hash is empty and the #16 placeholder is shown. The Lua converter returns the hash; the pdfLaTeX path exposes it via `\PlantUmlHash`. Removes the now-unused `.cache` machinery and ignores `plantuml-*.{tex,png,svg}`.

Trade-off (documented): hash-named files **accumulate** as diagrams are edited; delete `plantuml-*.{tex,png,svg}` to clear the cache.

### Testing (Docker, both engines)

A 3-diagram doc (two identical + one different):

| run | generations | cache hits | hash files |
|-----|-------------|-----------|-----------|
| fresh | 2 (X, Y) | 1 (dup of X) | 2 |
| recompile | **0** | 3 | 2 |
| after editing 1 diagram | 1 | 2 | 3 |

Also verified: `-output-directory`, cross-engine cache reuse (lualatex→pdflatex = 1 file + cache hit), and visual rendering of both a fresh and a cache-served diagram.

`CHANGELOG.md` passes `heylogs check`.