### PR TITLE
Rename the output-directory CI artifact to local-*

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -81,7 +81,9 @@ jobs:
           done
       - uses: actions/upload-artifact@v7
         with:
-          name: output-directory-${{ matrix.engine }}
+          # "local" (rendered by the local plantuml.jar), to parallel the
+          # server-* artifacts from the server job.
+          name: local-${{ matrix.engine }}
           path: out/*.pdf
   server:
     # Regression test for #6: render diagrams through a PlantUML server instead of


### PR DESCRIPTION
The `check.yml` `output-directory` job renders the examples with the **local** `plantuml.jar`, while the `server` job renders via the PlantUML server. The uploaded artifacts were `output-directory-{lualatex,pdflatex}` and `server-{lualatex,pdflatex}`, which don't read as a pair.

Rename the former to `local-{lualatex,pdflatex}` so the artifacts parallel cleanly: **local** (jar) vs **server**. The job name is unchanged — it's still the #27 `-output-directory` regression.

CI-only change (artifact name); YAML validated.