### PR TITLE
Prepare release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-06-29
+
 ### Added
 
 - Added support for `pdflatex`. PlantUML is now driven directly via shell escape, mirroring the LuaLaTeX path (same `plantuml.jar` invocation and MD5-based source caching). [#1](https://github.com/koppor/plantuml/issues/1)
@@ -127,7 +129,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Initial public release
 
-[Unreleased]: https://github.com/koppor/plantuml/compare/0.6.0...HEAD
+[Unreleased]: https://github.com/koppor/plantuml/compare/0.7.0...HEAD
+[0.7.0]: https://github.com/koppor/plantuml/compare/0.6.0...0.7.0
 [0.6.0]: https://github.com/koppor/plantuml/compare/0.5.1...0.6.0
 [0.5.1]: https://github.com/koppor/plantuml/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/koppor/plantuml/compare/0.4.0...0.5.0

--- a/plantuml.sty
+++ b/plantuml.sty
@@ -1,9 +1,9 @@
-%% Copyright (C) 2018-2025 Oliver Kopp and contributors
+%% Copyright (C) 2018-2026 Oliver Kopp and contributors
 %%
 %% SPDX-License-Identifier: LPPL-1.3c+
 \NeedsTeXFormat{LaTeX2e}\relax
 \ProvidesPackage{plantuml}
-  [2025/05/13 v0.6.0
+  [2026/06/29 v0.7.0
   Embed PlantUML diagrams in latex documents.]
 
 % Required by PlantUML LaTeX output


### PR DESCRIPTION
Release preparation for **0.7.0** (per the README "Development" steps).

- `plantuml.sty`: version → `v0.7.0` (`2026/06/29`); copyright year → `2018-2026`.
- `CHANGELOG.md`: `[Unreleased]` rolled over to `[0.7.0] - 2026-06-29`, fresh empty `[Unreleased]` added, `0.7.0` comparison link added. Passes `heylogs check`.

### What 0.7.0 contains (since 0.6.0)
Added: pdflatex support (#1), PlantUML server rendering (#6), content-addressed caching (#2), `\plantumlinput` (#3), optional `@startuml`/`@enduml` (#4), global preamble (#5), `caption`/`label`/`float` (#8), beamer example (#11).
Changed: graceful placeholder instead of aborting (#16), sans-serif TikZ default (#14), SVG README previews with the cerulean-outline theme.
Fixed: `-output-directory` (#27), SVG text as paths (#25), jar paths with spaces (#7), the `#` protected marker example (#24).

### After merge
I'll tag the merge commit `0.7.0` and push the tag (with your go-ahead). The CTAN package (`plantuml.tar.gz`) is produced as a workflow artifact for manual upload to CTAN.

Note: `release.yml` builds on push to `main`, and `release.sh` stamps the version from the latest git tag — so for the artifact to read `0.7.0`, the build needs to run with the `0.7.0` tag present (e.g. re-run the workflow after tagging). Happy to add a `workflow_dispatch`/tag trigger (and `fetch-depth: 0` so `git describe` sees the tag) in a follow-up if you'd like the release build to be one-click.