### PR TITLE
Try the PlantUML snapshot with automatic LaTeX-engine detection

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,20 +27,17 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-      # PlantUML is pinned; bump the version here (see CLAUDE.md). The cache is
-      # keyed on the version, so a bump fetches the new jar automatically.
-      - name: Set PlantUML version
-        id: plantuml-version
-        run: echo "version=1.2026.6" >> "$GITHUB_OUTPUT"
-      - name: Download PlantUML jar (cached)
-        id: plantuml-jar
-        uses: ethanjli/cached-download-action@v0.1.4
-        with:
-          url: https://github.com/plantuml/plantuml/releases/download/v${{ steps.plantuml-version.outputs.version }}/plantuml-${{ steps.plantuml-version.outputs.version }}.jar
-          destination: /tmp/plantuml/plantuml-${{ steps.plantuml-version.outputs.version }}.jar
-          cache-key: plantuml-${{ steps.plantuml-version.outputs.version }}.jar
-      - name: Set PLANTUML_JAR
-        run: echo "PLANTUML_JAR=${{ steps.plantuml-jar.outputs.destination }}" >> "$GITHUB_ENV"
+      # TEMPORARY (plantuml/plantuml#2764): validate upstream's LaTeX-engine
+      # auto-detection against the PlantUML snapshot, which drops the hardcoded
+      # xelatex dependency, before it ships in a stable release. The snapshot is a
+      # moving tag, so fetch it fresh each run (no version pin / cache); re-pin to
+      # a released version before merging -- see CLAUDE.md.
+      - name: Download PlantUML snapshot jar
+        run: |
+          mkdir -p /tmp/plantuml
+          curl -fSL -o /tmp/plantuml/plantuml-SNAPSHOT.jar \
+            https://github.com/plantuml/plantuml/releases/download/snapshot/plantuml-SNAPSHOT.jar
+          echo "PLANTUML_JAR=/tmp/plantuml/plantuml-SNAPSHOT.jar" >> "$GITHUB_ENV"
       - uses: actions/checkout@v7
       - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,18 +31,17 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-      - name: Set PlantUML version
-        id: plantuml-version
-        run: echo "version=1.2026.6" >> "$GITHUB_OUTPUT"
-      - name: Download PlantUML jar (cached)
-        id: plantuml-jar
-        uses: ethanjli/cached-download-action@v0.1.4
-        with:
-          url: https://github.com/plantuml/plantuml/releases/download/v${{ steps.plantuml-version.outputs.version }}/plantuml-${{ steps.plantuml-version.outputs.version }}.jar
-          destination: /tmp/plantuml/plantuml-${{ steps.plantuml-version.outputs.version }}.jar
-          cache-key: plantuml-${{ steps.plantuml-version.outputs.version }}.jar
-      - name: Set PLANTUML_JAR
-        run: echo "PLANTUML_JAR=${{ steps.plantuml-jar.outputs.destination }}" >> "$GITHUB_ENV"
+      # TEMPORARY (plantuml/plantuml#2764): validate upstream's LaTeX-engine
+      # auto-detection against the PlantUML snapshot, which drops the hardcoded
+      # xelatex dependency, before it ships in a stable release. The snapshot is a
+      # moving tag, so fetch it fresh each run (no version pin / cache); re-pin to
+      # a released version before merging -- see CLAUDE.md.
+      - name: Download PlantUML snapshot jar
+        run: |
+          mkdir -p /tmp/plantuml
+          curl -fSL -o /tmp/plantuml/plantuml-SNAPSHOT.jar \
+            https://github.com/plantuml/plantuml/releases/download/snapshot/plantuml-SNAPSHOT.jar
+          echo "PLANTUML_JAR=/tmp/plantuml/plantuml-SNAPSHOT.jar" >> "$GITHUB_ENV"
       - uses: actions/checkout@v7
       - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:
@@ -98,18 +97,17 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-      - name: Set PlantUML version
-        id: plantuml-version
-        run: echo "version=1.2026.6" >> "$GITHUB_OUTPUT"
-      - name: Download PlantUML jar (cached)
-        id: plantuml-jar
-        uses: ethanjli/cached-download-action@v0.1.4
-        with:
-          url: https://github.com/plantuml/plantuml/releases/download/v${{ steps.plantuml-version.outputs.version }}/plantuml-${{ steps.plantuml-version.outputs.version }}.jar
-          destination: /tmp/plantuml/plantuml-${{ steps.plantuml-version.outputs.version }}.jar
-          cache-key: plantuml-${{ steps.plantuml-version.outputs.version }}.jar
-      - name: Set PLANTUML_JAR
-        run: echo "PLANTUML_JAR=${{ steps.plantuml-jar.outputs.destination }}" >> "$GITHUB_ENV"
+      # TEMPORARY (plantuml/plantuml#2764): validate upstream's LaTeX-engine
+      # auto-detection against the PlantUML snapshot, which drops the hardcoded
+      # xelatex dependency, before it ships in a stable release. The snapshot is a
+      # moving tag, so fetch it fresh each run (no version pin / cache); re-pin to
+      # a released version before merging -- see CLAUDE.md.
+      - name: Download PlantUML snapshot jar
+        run: |
+          mkdir -p /tmp/plantuml
+          curl -fSL -o /tmp/plantuml/plantuml-SNAPSHOT.jar \
+            https://github.com/plantuml/plantuml/releases/download/snapshot/plantuml-SNAPSHOT.jar
+          echo "PLANTUML_JAR=/tmp/plantuml/plantuml-SNAPSHOT.jar" >> "$GITHUB_ENV"
       - uses: actions/checkout@v7
       - uses: awalsh128/cache-apt-pkgs-action@v1.6.1
         with:

--- a/example-class-visibility--latex.tex
+++ b/example-class-visibility--latex.tex
@@ -4,9 +4,10 @@
 % file -- including characters LaTeX treats specially, such as "#". Write them
 % as-is; do NOT escape them (e.g. use "#balance", not "\#balance"). See #24.
 %
-% LaTeX/TikZ output (PlantUML's -tlatex). Note: PlantUML invokes xelatex
-% internally to measure text for TikZ output; see also example-class-visibility
-% in --png and --svg variants, which do not need xelatex.
+% LaTeX/TikZ output (PlantUML's -tlatex). To measure text for TikZ, PlantUML
+% auto-detects an installed LaTeX engine (lualatex, xelatex, or pdflatex), so no
+% specific engine is required; see also the --png and --svg variants, which need
+% no LaTeX engine at all.
 \documentclass{scrartcl}
 \usepackage[output=latex]{plantuml}
 \begin{document}

--- a/example-class-visibility--png.tex
+++ b/example-class-visibility--png.tex
@@ -4,7 +4,7 @@
 % file -- including characters LaTeX treats specially, such as "#". Write them
 % as-is; do NOT escape them (e.g. use "#balance", not "\#balance"). See #24.
 %
-% PNG output: needs graphviz, but no xelatex and no inkscape.
+% PNG output: needs graphviz, but no LaTeX engine and no inkscape.
 \documentclass{scrartcl}
 \usepackage[output=png]{plantuml}
 \begin{document}

--- a/example-class-visibility--svg.tex
+++ b/example-class-visibility--svg.tex
@@ -4,7 +4,7 @@
 % file -- including characters LaTeX treats specially, such as "#". Write them
 % as-is; do NOT escape them (e.g. use "#balance", not "\#balance"). See #24.
 %
-% SVG output: needs graphviz and inkscape, but no xelatex.
+% SVG output: needs graphviz and inkscape, but no LaTeX engine.
 \documentclass{scrartcl}
 
 \usepackage{graphics}

--- a/example-server--png.tex
+++ b/example-server--png.tex
@@ -7,7 +7,7 @@
 % drop the option and set the PLANTUML_SERVER environment variable.
 %
 % Only png and svg work via a server; latex/TikZ output always uses the jar.
-% PNG output needs neither inkscape nor xelatex.
+% PNG output needs neither inkscape nor a LaTeX engine.
 \documentclass{scrartcl}
 \usepackage[output=png, server=http://localhost:8080]{plantuml}
 \begin{document}

--- a/plantuml.lua
+++ b/plantuml.lua
@@ -135,17 +135,6 @@ function convertPlantUmlToTikz(jobname, mode, iodir, server, sourceFile, preambl
       cmd = cmd .. mode
     end
     cmd = cmd .. [[ < "]] .. plantUmlSourceFilename .. [[" > "]] .. plantUmlTargetFilename .. [["]]
-    -- PlantUML's TikZ output runs xelatex internally to measure text, and that
-    -- xelatex hangs when TEXMF_OUTPUT_DIRECTORY holds a relative path (set by
-    -- lualatex's -output-directory). Clear it for the PlantUML child via a command
-    -- prefix -- os.setenv is not reliable for io.popen children across builds. (#27)
-    if os.getenv("TEXMF_OUTPUT_DIRECTORY") then
-      if package.config:sub(1, 1) == "\\" then
-        cmd = [[set "TEXMF_OUTPUT_DIRECTORY=" && ]] .. cmd
-      else
-        cmd = "env -u TEXMF_OUTPUT_DIRECTORY " .. cmd
-      end
-    end
   end
   texio.write_nl(cmd)
   local handle,error = io.popen(cmd)

--- a/plantuml.lua
+++ b/plantuml.lua
@@ -135,6 +135,19 @@ function convertPlantUmlToTikz(jobname, mode, iodir, server, sourceFile, preambl
       cmd = cmd .. mode
     end
     cmd = cmd .. [[ < "]] .. plantUmlSourceFilename .. [[" > "]] .. plantUmlTargetFilename .. [["]]
+    -- PlantUML shells out to a LaTeX engine to measure text for TikZ output, and
+    -- that engine hangs when TEXMF_OUTPUT_DIRECTORY holds a relative path (set by
+    -- lualatex's -output-directory). Recent PlantUML clears it internally, but do
+    -- it here too so older jars keep working -- harmless on newer ones. A command
+    -- prefix is used because os.setenv is not reliable for io.popen children across
+    -- builds. (#27, plantuml/plantuml#2764)
+    if os.getenv("TEXMF_OUTPUT_DIRECTORY") then
+      if package.config:sub(1, 1) == "\\" then
+        cmd = [[set "TEXMF_OUTPUT_DIRECTORY=" && ]] .. cmd
+      else
+        cmd = "env -u TEXMF_OUTPUT_DIRECTORY " .. cmd
+      end
+    end
   end
   texio.write_nl(cmd)
   local handle,error = io.popen(cmd)

--- a/tl_packages
+++ b/tl_packages
@@ -40,5 +40,4 @@ scheme-minimal
 standalone
 varwidth
 xcolor
-xetex
 xkeyval


### PR DESCRIPTION
## What

Upstream ([plantuml/plantuml#2764](https://github.com/plantuml/plantuml/issues/2764)) replaced PlantUML's hardcoded `xelatex` text measurement for `-tlatex`/TikZ output with automatic engine detection: it probes `lualatex → xelatex → pdflatex` (an explicit `!pragma tex_system` overriding), and falls back to AWT font metrics when no LaTeX engine is present. This is in the current `snapshot` build (`1.2026.7beta6 / f02af54`), not yet in a stable release.

This PR runs the repo's CI against that snapshot and adjusts the package accordingly:

- **`tl_packages`**: remove `xetex` — the TikZ examples now measure with the installed `lualatex`/`pdflatex`, proving the lualatex-only setup works.
- **`plantuml.lua`**: **keep** the `TEXMF_OUTPUT_DIRECTORY` guard — it's harmless on newer PlantUML (which clears the variable internally) and still required for older jars, so keeping it maximises version compatibility. Only its comment is refreshed (no longer hardcodes "xelatex").
- Update the `--latex`/`--png`/`--svg`/server example comments that referred to xelatex.

## Draft — one thing to resolve before merge

CI fetches the **moving `snapshot` tag** instead of a pinned release (no version pin / cache), contradicting the pinning model in `CLAUDE.md`. Re-pin to a stable release once one ships the fix, then this is ready.

## Verification

Reproduced locally in Docker (`texlive/texlive` + Temurin 21), simulating engine absence by hiding binaries:

| Scenario | Result |
|---|---|
| xelatex absent (this repo's CI setup) | **byte-identical** output to a full install (lualatex) |
| pdflatex only | non-empty output |
| no LaTeX engine at all | AWT fallback, non-empty output |
| `!pragma tex_system pdflatex` | forces pdflatex (byte-identical to a real pdflatex-only run) |
| CI-style `lualatex -shell-escape -output-directory=out`, xelatex removed | 8674-byte PDF — **identical whether the `plantuml.lua` guard is present or not** (guard is harmless on the fixed jar) |

The repo's own Check / Release runs are the end-to-end confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
